### PR TITLE
fix: disregard classes order

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -390,7 +390,7 @@ export class Processor {
     const success: string[] = [];
     const ignored: string[] = [];
     const styleSheet = new StyleSheet();
-    let className: string | undefined = prefix + hash(classNames.trim().split(/\s+/g).join(' '));
+    let className: string | undefined = prefix + hash(classNames.trim().split(/\s+/g).sort().join(' '));
     if (ignoreGenerated && this._cache.classes.includes(className))
       return { success, ignored, styleSheet, className };
     const buildSelector = "." + className;


### PR DESCRIPTION
Generate only one class irrespective of the classes order.

Example:
```vue
  <div class="rounded shadow w-200px h-$height bg-$color transition-all" />
  <div class="rounded h-$height bg-$color shadow w-200px transition-all" />
```

This will generate a single compiled class.