### PR TITLE
Failed test - typography extend bug

### DIFF
--- a/test/plugin/typography.test.ts
+++ b/test/plugin/typography.test.ts
@@ -4,7 +4,19 @@ import typography from "../../src/plugin/typography";
 
 describe("aspect ratio plugin", () => {
   it("interpret test", () => {
-    const processor = new Processor();
+    const processor = new Processor({
+      theme: {
+        extend: {
+          typography: {
+            DEFAULT: {
+              css: {
+                color: 'red'
+              }
+            }
+          }
+        }
+      }
+    });
     processor.loadPluginWithOptions(typography);
     const classes = `
       prose


### PR DESCRIPTION
This PR adds a FAILED tests:

When using `theme: extend` with the typography plugin, it will generate incorrect CSS.

Config (it works fine if you don't extend it).

```js
theme: {
  extend: {
    typography: {
      DEFAULT: {
        css: {
          color: 'red'
        }
      }
    }
  }
}
```

You can see the generated `typography.css`:

```css
.prose {
  color: red;
}
.prose 0 {
  color: #374151;
  max-width: 65ch;
}
.prose 0 [class~="lead"] {
  color: #4b5563;
}
.prose 0 a {
  color: #111827;
  text-decoration: underline;
  font-weight: 500;
}
.prose 0 strong {
  color: #111827;
  font-weight: 600;
}
.prose 0 ol[type="A"] {
  --list-counter-style: upper-alpha;
}
/* ... */
```