### PR TITLE
fix: custom prefixes and screen prefixes

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -348,8 +348,8 @@ export class Processor {
           result = result.map(i => {
             if (i instanceof Keyframes) return i;
             const copy = deepCopy(i);
-            if (i.selector!.indexOf(':') > -1) {
-              copy.selector = i.selector!.split(':')
+            if (i.selector && i.selector.indexOf(':') > -1) {
+              copy.selector = i.selector.split(':')
                 .map((part, idx) => idx === 0 ? escapedSelector : part)
                 .join(':');
             }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -337,7 +337,7 @@ export class Processor {
         ignored.push(selector);
         return;
       }
-      const result = this.extract(baseClass);
+      let result = this.extract(baseClass);
       if (result) {
         success.push(selector);
         const escapedSelector = '.' + cssEscape(selector);
@@ -345,9 +345,14 @@ export class Processor {
           result.selector = escapedSelector;
           this.markAsImportant(result, important);
         } else if (Array.isArray(result)) {
-          result.forEach(i => {
-            if (i instanceof Container) i.selector = escapedSelector;
-            this.markAsImportant(i, important);
+          result = result.map(i => {
+            if (i instanceof Keyframes) return i;
+            const copy = new (i instanceof Container ? Container : Style)();
+            copy.extend(i);
+            if (i instanceof Keyframes) return copy;
+            copy.selector = escapedSelector;
+            this.markAsImportant(copy, important);
+            return copy;
           });
         }
         styleSheet.add(this.wrapWithVariants(variants, result));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -347,9 +347,7 @@ export class Processor {
         } else if (Array.isArray(result)) {
           result = result.map(i => {
             if (i instanceof Keyframes) return i;
-            const copy = new (i instanceof Container ? Container : Style)();
-            copy.extend(i);
-            if (i instanceof Keyframes) return copy;
+            const copy = deepCopy(i);
             copy.selector = escapedSelector;
             this.markAsImportant(copy, important);
             return copy;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -348,7 +348,14 @@ export class Processor {
           result = result.map(i => {
             if (i instanceof Keyframes) return i;
             const copy = deepCopy(i);
-            copy.selector = escapedSelector;
+            if (i.selector!.indexOf(':') > -1) {
+              copy.selector = i.selector!.split(':')
+                .map((part, idx) => idx === 0 ? escapedSelector : part)
+                .join(':');
+            }
+            else {
+              copy.selector = escapedSelector;
+            }
             this.markAsImportant(copy, important);
             return copy;
           });

--- a/test/plugin/__snapshots__/aspectRatio.test.ts.yml
+++ b/test/plugin/__snapshots__/aspectRatio.test.ts.yml
@@ -1,0 +1,90 @@
+Tools / interpret test / aspect-ratio base / 0: |-
+  .aspect-none {
+    position: static;
+    padding-bottom: 0;
+  }
+  .aspect-none > * {
+    position: static;
+    height: auto;
+    width: auto;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+  .aspect-w-16 {
+    --tw-aspect-w: 16;
+    position: relative;
+    padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
+  }
+  .aspect-w-16 > * {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .aspect-h-9 {
+    --tw-aspect-h: 9;
+  }
+  .aspect-9\/16 {
+    position: relative;
+    padding-bottom: 56.25%;
+  }
+  .aspect-9\/16 > * {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+Tools / works with prefix / aspect-ratio with prefix / 0: |-
+  .windi-aspect-none {
+    position: static;
+    padding-bottom: 0;
+  }
+  .windi-aspect-none > * {
+    position: static;
+    height: auto;
+    width: auto;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+  .windi-aspect-w-16 {
+    --tw-aspect-w: 16;
+    position: relative;
+    padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
+  }
+  .windi-aspect-w-16 > * {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .windi-aspect-h-9 {
+    --tw-aspect-h: 9;
+  }
+  @media (min-width: 640px) {
+    .sm\:windi-aspect-9\/16 {
+      position: relative;
+      padding-bottom: 56.25%;
+    }
+    .sm\:windi-aspect-9\/16 > * {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+  }

--- a/test/plugin/__snapshots__/lineClamp.test.ts.yml
+++ b/test/plugin/__snapshots__/lineClamp.test.ts.yml
@@ -1,0 +1,78 @@
+Tools / customize test / line-clamp customized / 0: |-
+  .line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+  .line-clamp-4 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+  .line-clamp-sm {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+  .line-clamp-md {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 6;
+  }
+Tools / interpret test / line-clamp / 0: |-
+  .line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+  .line-clamp-4 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+  .line-clamp-none {
+    -webkit-line-clamp: unset;
+  }
+  .hover\:line-clamp-none:hover {
+    -webkit-line-clamp: unset;
+  }
+  @media (min-width: 640px) {
+    .sm\:line-clamp-none {
+      -webkit-line-clamp: unset;
+    }
+  }
+Tools / works with prefix / line-clamp with prefix / 0: |-
+  .windi-line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+  }
+  .windi-line-clamp-4 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+  .windi-line-clamp-none {
+    -webkit-line-clamp: unset;
+  }
+  @media (min-width: 640px) {
+    .sm\:windi-line-clamp-none {
+      -webkit-line-clamp: unset;
+    }
+  }
+  @media (min-width: 768px) {
+    .md\:windi-line-clamp-4 {
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 4;
+    }
+  }

--- a/test/plugin/aspectRatio.test.ts
+++ b/test/plugin/aspectRatio.test.ts
@@ -13,49 +13,19 @@ describe('aspect ratio plugin', () => {
       `;
     const utility = processor.interpret(classes);
     expect(utility.ignored.length).toEqual(0);
-    expect(utility.styleSheet.build()).toEqual(
-      String.raw`.aspect-none {
-  position: static;
-  padding-bottom: 0;
-}
-.aspect-none > * {
-  position: static;
-  height: auto;
-  width: auto;
-  top: auto;
-  right: auto;
-  bottom: auto;
-  left: auto;
-}
-.aspect-w-16 {
-  --tw-aspect-w: 16;
-  position: relative;
-  padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
-}
-.aspect-w-16 > * {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-.aspect-h-9 {
-  --tw-aspect-h: 9;
-}
-.aspect-9\/16 {
-  position: relative;
-  padding-bottom: 56.25%;
-}
-.aspect-9\/16 > * {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}`);
+    expect(utility.styleSheet.build()).toMatchSnapshot('aspect-ratio base');
+  });
+  it('works with prefix', () => {
+    const processor = new Processor({ prefix: 'windi-' });
+    processor.loadPlugin(aspectRatio);
+    const classes = `
+      windi-aspect-none
+      windi-aspect-w-16
+      windi-aspect-h-9
+      sm:windi-aspect-9/16
+      `;
+    const utility = processor.interpret(classes);
+    expect(utility.ignored.length).toEqual(0);
+    expect(utility.styleSheet.build()).toMatchSnapshot('aspect-ratio with prefix');
   });
 });

--- a/test/plugin/lineClamp.test.ts
+++ b/test/plugin/lineClamp.test.ts
@@ -14,30 +14,7 @@ describe('line clamp plugin', () => {
     `;
     const result = processor.interpret(classes);
     expect(result.ignored.length).toEqual(0);
-    expect(result.styleSheet.build()).toEqual(
-      `.line-clamp-1 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-}
-.line-clamp-4 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
-}
-.line-clamp-none {
-  -webkit-line-clamp: unset;
-}
-.hover\\:line-clamp-none:hover {
-  -webkit-line-clamp: unset;
-}
-@media (min-width: 640px) {
-  .sm\\:line-clamp-none {
-    -webkit-line-clamp: unset;
-  }
-}`);
+    expect(result.styleSheet.build()).toMatchSnapshot('line-clamp');
   });
   it('customize test', () => {
     const processor = new Processor({
@@ -52,30 +29,20 @@ describe('line clamp plugin', () => {
     `;
     const result = processor.interpret(classes);
     expect(result.ignored.length).toEqual(0);
-    expect(result.styleSheet.build()).toEqual(
-      `.line-clamp-1 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-}
-.line-clamp-4 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
-}
-.line-clamp-sm {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
-}
-.line-clamp-md {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 6;
-}`);
+    expect(result.styleSheet.build()).toMatchSnapshot('line-clamp customized');
+  });
+  it('works with prefix', () => {
+    const processor = new Processor({ prefix: 'windi-' });
+    processor.loadPlugin(lineClamp);
+    const classes = `
+      windi-line-clamp-1
+      windi-line-clamp-4
+      windi-line-clamp-none
+      sm:windi-line-clamp-none
+      md:windi-line-clamp-4
+    `;
+    const result = processor.interpret(classes);
+    expect(result.ignored.length).toEqual(0);
+    expect(result.styleSheet.build()).toMatchSnapshot('line-clamp with prefix');
   });
 });

--- a/test/processor/__snapshots__/config.test.ts.yml
+++ b/test/processor/__snapshots__/config.test.ts.yml
@@ -1,3 +1,25 @@
+Tools / allows to use prefix with shortcuts / shortcuts with prefix / 0: |-
+  .windi-btn {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-weight: 600;
+    border-radius: 0.5rem;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  }
+  .windi-btn-green {
+    --tw-text-opacity: 1;
+    color: rgba(255, 255, 255, var(--tw-text-opacity));
+    --tw-bg-opacity: 1;
+    background-color: rgba(16, 185, 129, var(--tw-bg-opacity));
+  }
+  .windi-btn-green:hover {
+    --tw-bg-opacity: 1;
+    background-color: rgba(4, 120, 87, var(--tw-bg-opacity));
+  }
 Tools / animation config test / animate / 0: |-
   @keyframes skbounce {
     0%, 100% {
@@ -115,7 +137,7 @@ Tools / shortcuts config string / shortcuts string / 0: |-
     background-color: rgba(4, 120, 87, var(--tw-bg-opacity));
   }
   @media (min-width: 1024px) {
-    .btn {
+    .lg\:btn {
       padding-top: 0.5rem;
       padding-bottom: 0.5rem;
       padding-left: 1rem;

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -53,7 +53,7 @@ Tools / animation test / animate-ping / 0: |-
     }
   }
   @media (min-width: 640px) {
-    .animate-ping {
+    .sm\:animate-ping {
       -webkit-animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
       animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
     }

--- a/test/processor/config.test.ts
+++ b/test/processor/config.test.ts
@@ -277,4 +277,18 @@ describe('Config', () => {
     });
     expect(processor.interpret('btn').styleSheet.build()).toMatchSnapshot('shortcuts object');
   });
+  it('allows to use prefix with shortcuts', () => {
+    const processor = new Processor({
+      prefix: 'windi-',
+      shortcuts: {
+        'btn': 'py-2 px-4 font-semibold rounded-lg shadow-md',
+        'btn-green': {
+          '@apply': 'text-white bg-green-500 hover:bg-green-700',
+        },
+      },
+    });
+    const result = processor.interpret('windi-btn windi-btn-green');
+    expect(result.ignored.length).toEqual(0);
+    expect(result.styleSheet.build()).toMatchSnapshot('shortcuts with prefix');
+  });
 });


### PR DESCRIPTION
Hi,
this tries to fix #105 
this also fixes some screen prefixes eg for .sm:animate-spin or .lg:btn
~~this still has a problem with the :hover in the "shortcuts config object" test
Does anybody have an idea how to fix?~~