### PR TITLE
[scroll-snap plugin] add .no-snap to reset snap effect

### DIFF
--- a/src/plugin/scroll-snap/index.ts
+++ b/src/plugin/scroll-snap/index.ts
@@ -44,6 +44,11 @@ export default plugin(
           'var(--scroll-snap-axis, both) var(--scroll-snap-strictness, mandatory)',
       },
 
+      // scroll-snap-type to none
+      '.no-snap': {
+        'scroll-snap-type': 'none',
+      },
+
       // strictness
       // https://www.w3.org/TR/css-scroll-snap-1/#snap-strictness
       ...fromEntries(

--- a/test/plugin/scrollSnap.test.ts
+++ b/test/plugin/scrollSnap.test.ts
@@ -7,6 +7,7 @@ describe('Scroll Snap plugin', () => {
     processor.loadPlugin(scrollSnap);
     const classes = `
       scrollbar-hide
+      no-snap
       snap
       snap-start
       snap-end


### PR DESCRIPTION
Tailwindcss-scroll-snap provides a .no-snap class to reset snap effet. Ref [here](https://github.com/innocenzi/tailwindcss-scroll-snap#type).

This is useful to reset the snap effect with responsive/breakpoints. (My use case : snap on mobile, no-snap on desktop).

Thanks for your amazing work!