### PR TITLE
Adds support for container.screens config

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -22,7 +22,7 @@ function container(utility: Utility, { theme }: PluginUtils): Output {
     }
     if (theme('container.center')) baseStyle.add(new Property(['margin-left', 'margin-right'], 'auto'));
     const output: Container[] = [baseStyle];
-    const screens = toType(theme('screens'), 'object') ?? {};
+    const screens = toType(theme('container.screens', theme('screens')), 'object') ?? {};
     for (const [screen, size] of Object.entries(screens)) {
       const props = [new Property('max-width', `${size}`)];
       const padding = theme(`container.padding.${screen}`);


### PR DESCRIPTION
While not documented, tailwindcss' container component has support for specific screens configuration.
https://github.com/tailwindlabs/tailwindcss/blob/38b4eeb288ec5e43c28c6ffbc7f3353120c475fd/src/plugins/container.js#L71
This adds the same behaviour to windicss.