### PR TITLE
fix: add grid-(column-|row-)gap for older browsers

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -266,7 +266,7 @@ function gridAuto(utility: Utility, { theme }: PluginUtils): Output {
 }
 
 // https://tailwindcss.com/docs/gap
-function gap(utility: Utility, { theme }: PluginUtils): Output {
+function gap(utility: Utility, { theme, config }: PluginUtils): Output {
   const value = utility.handler
     .handleStatic(theme('gap'))
     .handleSpacing()
@@ -275,13 +275,19 @@ function gap(utility: Utility, { theme }: PluginUtils): Output {
   if (!value) return;
   if (utility.raw.match(/^gap-x-/)) {
     return new Property(
-      ['-webkit-column-gap', '-moz-column-gap', 'column-gap'],
+      config('prefixer') ? ['-webkit-column-gap', '-moz-column-gap', 'grid-column-gap', 'column-gap'] : 'column-gap',
       value
     );
   } else if (utility.raw.match(/^gap-y-/)) {
-    return new Property('row-gap', value);
+    return new Property(
+      config('prefixer') ? ['-webkit-row-gap', '-moz-row-gap', 'grid-row-gap', 'row-gap'] : 'row-gap',
+      value
+    );
   } else {
-    return new Property('gap', value);
+    return new Property(
+      config('prefixer') ? ['grid-gap', 'gap'] : 'gap',
+      value
+    );
   }
 }
 


### PR DESCRIPTION
Hi,
i added grid-gap, grid-column-gap, grid-row-gap for older browsers if prefixer is enabled
for example Safari before 12.1 still used the old syntax:
https://caniuse.com/mdn-css_properties_column-gap_grid_context