### PR TITLE
fix: allow last rule in block without semicolon

### DIFF
--- a/src/utils/parser/css.ts
+++ b/src/utils/parser/css.ts
@@ -142,7 +142,7 @@ export default class CSSParser {
         index = nestStart + 1;
         const nestEnd = this._searchGroup(css, index);
         if (nestEnd === -1) break; // doesn't close block
-        const content = this.parse(css.slice(index, nestEnd), selector);
+        const content = this.parse(css.slice(index, nestEnd).replace(/(?<![};])\s*$/, ';'), selector);
         index = nestEnd + 1;
         styleSheet.add(this._generateNestStyle(content.children, selector, css.charAt(firstLetter) === '@' ? 'atRule': 'selector'));
 

--- a/test/parser/css.test.ts
+++ b/test/parser/css.test.ts
@@ -274,4 +274,10 @@ describe('CSSParser', () => {
     const parser = new CSSParser(css, PROCESSOR);
     expect(parser.parse().build()).toMatchSnapshot('css');
   });
+
+  it('allow last rule without semicolon', () => {
+    const css = '.btn-red {background-color: red   }';
+    const parser = new CSSParser(css, PROCESSOR);
+    expect(parser.parse().build()).toEqual('.btn-red {\n  background-color: red;\n}');
+  });
 });


### PR DESCRIPTION
fixes #139
another option would be:
const content = this.parse(css.slice(index, nestEnd) + ';', selector);
or maybe theres a better approach?