### PR TITLE
fix: apply placeholder-opacity with placeholder-color

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -473,12 +473,12 @@ function listStyleType(utility: Utility, { theme }: PluginUtils): Output {
 function placeholder(utility: Utility, { theme, config }: PluginUtils, variants: string[]): Output {
   // handle placeholder opacity
   if (utility.raw.startsWith('placeholder-opacity')) {
-    return utility.handler
+    const opacity = utility.handler
       .handleStatic(theme('placeholderOpacity'))
       .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
       .handleVariable()
-      .createProperty('--tw-placeholder-opacity')
-      ?.updateMeta({ type: 'utilities', corePlugin: true, group: 'placeholderOpacity', order: pluginOrder['placeholderOpacity'] + 1 });
+      .value;
+    return generatePlaceholder(utility.class, new Property('--tw-placeholder-opacity', opacity), config('prefixer') as boolean).map(function (style) { return style.updateMeta({ type: 'utilities', corePlugin: true, group: 'placeholderOpacity', order: pluginOrder['placeholderOpacity'] + 1 }); });
   }
   const handler = utility.handler.handleColor(theme('placeholderColor')).handleVariable();
   if (!handler.value) return;


### PR DESCRIPTION
For example when you have both `.placeholder-emerald-400` and `.placeholder-opacity-40`, the style below will be used.

```css
.placeholder-opacity-40 {
    --tw-placeholder-opacity: 0.4;
}
.placeholder-emerald-400::placeholder {
    --tw-placeholder-opacity: 1;
    color: rgba(52, 211, 153, var(--tw-placeholder-opacity));
}
```

Because `--tw-placeholder-opacity` is overridden by `.placeholder-emerald-400`'s one, `.placeholder-opacity-40` will not be applied.

This PR changes `.placeholder-opacity-40`'s style to below.
```css
.placeholder-opacity-40::placeholder {
    --tw-placeholder-opacity: 0.4;
}
```
