### PR TITLE
feat(types): update types to have centerized options for tools

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,5 +1,5 @@
-import type { Config } from '../interfaces';
+import type { FullConfig } from '../interfaces';
 
-export function defineConfig(config: Config): Config {
+export function defineConfig(config: FullConfig): FullConfig {
   return config;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -243,21 +243,6 @@ export interface Config {
   exclude?: RegExp[];
   shortcuts?: {[key:string]: Shortcut};
 
-  // ===== Tools Options =====
-  /**
-   * Safelist of utilities that will always be included in the generated CSS
-   */
-  safelist?: string | (string | string[])[];
-  /**
-   * Extractions options
-   */
-  extract?: ExtractOptions
-  /**
-   * Preflight options
-   * Set `false` to disable preflight
-   */
-  preflight?: PreflightOptions | false
-
   // ===== Depreacted =====
   /**
    * @deprecated no longer needed for Windi CSS
@@ -273,22 +258,21 @@ export interface Config {
   [key:string]: any;
 }
 
-export type ProcessorConfig = Pick<
-  Config,
-  | 'presets'
-  | 'presets'
-  | 'prefixer'
-  | 'separator'
-  | 'important'
-  | 'dark'
-  | 'theme'
-  | 'variant'
-  | 'plugins'
-  | 'core'
-  | 'prefix'
-  | 'exclude'
-  | 'shortcuts'
->
+export interface FullConfig extends Config {
+  /**
+   * Safelist of utilities that will always be included in the generated CSS
+   */
+  safelist?: string | (string | string[])[];
+  /**
+   * Extractions options
+   */
+  extract?: ExtractOptions
+  /**
+   * Preflight options
+   * Set `false` to disable preflight
+   */
+  preflight?: PreflightOptions | false
+}
 
 export interface DefaultTheme {
   colors: { [key: string]: string | { [key: string]: string } };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -188,12 +188,53 @@ export type Shortcut = string | NestObject;
 
 export type DarkModeConfig = 'class' | 'media' | false;
 
+export interface ExtractorResultDetailed {
+  attributes?: {
+    names: string[];
+    values: string[];
+  };
+  classes?: string[];
+  ids?: string[];
+  tags?: string[];
+  undetermined?: string[];
+}
+
+export interface Extractor {
+  extractor: (content: string) => ExtractorResultDetailed | Promise<ExtractorResultDetailed>,
+  extensions: string[]
+}
+
+export interface ExtractOptions {
+  /**
+   * Globs of files to be included from extractions
+   */
+  include?: string[]
+  /**
+   * Globs of files to be excluded from extractions
+   *
+   * @default ['node_modules', '.git']
+   */
+  exclude?: string[]
+  /**
+   * Extractors to handle different file types.
+   * Compatible with PurgeCSS
+   */
+  extractors?: Extractor[]
+}
+
+export interface PreflightOptions {
+  /**
+   * Safelist of preflight that will always be included in the generated CSS
+   */
+  safelist?: string | (string | string[])[];
+}
+
 export interface Config {
   presets?: Config[];
   prefixer?: boolean;
   separator?: string;
   important?: boolean | string;
-  darkMode?: 'media' | 'class' | false;
+  darkMode?: DarkModeConfig;
   theme?: Theme;
   variantOrder?: string[];
   plugins?: Plugin[];
@@ -201,7 +242,23 @@ export interface Config {
   prefix?: string;
   exclude?: RegExp[];
   shortcuts?: {[key:string]: Shortcut};
-  [key:string]: any;
+
+  // ===== Tools Options =====
+  /**
+   * Safelist of utilities that will always be included in the generated CSS
+   */
+  safelist?: string | (string | string[])[];
+  /**
+   * Extractions options
+   */
+  extract?: ExtractOptions
+  /**
+   * Preflight options
+   * Set `false` to disable preflight
+   */
+  preflight?: PreflightOptions | false
+
+  // ===== Depreacted =====
   /**
    * @deprecated no longer needed for Windi CSS
    */
@@ -210,7 +267,28 @@ export interface Config {
    * @deprecated no longer needed for Windi CSS
    */
   variants?: { [key: string]: string[] };
+  /**
+   * Fallback
+   */
+  [key:string]: any;
 }
+
+export type ProcessorConfig = Pick<
+  Config,
+  | 'presets'
+  | 'presets'
+  | 'prefixer'
+  | 'separator'
+  | 'important'
+  | 'dark'
+  | 'theme'
+  | 'variant'
+  | 'plugins'
+  | 'core'
+  | 'prefix'
+  | 'exclude'
+  | 'shortcuts'
+>
 
 export interface DefaultTheme {
   colors: { [key: string]: string | { [key: string]: string } };


### PR DESCRIPTION
This PR only introduces changes to types, the implementation should be done on the tooling side.

A new type `FullConfig` is introduced for type `windi.config.ts` with extra options that consumed by tools but not the processor.