### PR TITLE
feat: support interpret square brackets

### DIFF
--- a/src/lib/utilities/handler.ts
+++ b/src/lib/utilities/handler.ts
@@ -189,7 +189,7 @@ export class Utility {
     return this.match(/-.+(?=-)/).substring(1); // real-gray
   }
   get amount(): string {
-    return this.match(/[^-]+$/); // 300
+    return this.match(/(?:[^-]+|\[.*?\])$/); // 300
   }
   get body(): string {
     return this.match(/-.+/).substring(1); // real-gray-300

--- a/src/lib/utilities/handler.ts
+++ b/src/lib/utilities/handler.ts
@@ -57,6 +57,12 @@ class Handler {
     }
     return this;
   }
+  handleSquareBrackets() {
+    if (this.value) return this;
+    if (this._amount[0] === '[' && this._amount[this._amount.length-1] === ']')
+      this._amount = this._amount.slice(1, -1);
+    return this;
+  }
   handleNumber(
     start = -Infinity,
     end = Infinity,
@@ -92,6 +98,7 @@ class Handler {
   }
   handleSize(callback?: (size: string) => string | undefined) {
     if (this.value) return this;
+    this.handleSquareBrackets();
     if (isSize(this._amount))
       this.value = callback ? callback(this._amount) : this._amount;
     return this;

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -58,7 +58,7 @@ export function isFraction(amount: string): boolean {
 }
 
 export function isSize(amount: string): boolean {
-  return /^(\d+(\.\d+)?)+(rem|em|px|vh|vw|ch|ex)$/.test(amount);
+  return /^-?(\d+(\.\d+)?)+(rem|em|px|vh|vw|ch|ex)$/.test(amount);
 }
 
 export function isSpace(str: string): boolean {

--- a/test/interface/__snapshots__/config.test.ts.yml
+++ b/test/interface/__snapshots__/config.test.ts.yml
@@ -461,8 +461,8 @@ Tools / should load all plugins correctly / css / 0: |-
     backdrop-filter: blur(20px);
   }
   .blur-20 {
-    -webkit-backdrop-filter: 20px;
-    backdrop-filter: 20px;
+    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
   }
   @media (min-width: 768px) {
     .md\:prose-lg {

--- a/test/interface/__snapshots__/config.test.ts.yml
+++ b/test/interface/__snapshots__/config.test.ts.yml
@@ -461,8 +461,8 @@ Tools / should load all plugins correctly / css / 0: |-
     backdrop-filter: blur(20px);
   }
   .blur-20 {
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: 20px;
+    backdrop-filter: 20px;
   }
   @media (min-width: 768px) {
     .md\:prose-lg {

--- a/test/processor/__snapshots__/interpret.test.ts.yml
+++ b/test/processor/__snapshots__/interpret.test.ts.yml
@@ -59,3 +59,13 @@ Tools / interpret important / important / 0: |-
     --tw-text-opacity: 1 !important;
     color: rgba(110, 231, 183, var(--tw-text-opacity)) !important;
   }
+Tools / interpret square brackets / square brackets / 0: |-
+  .\!mt-\[10px\] {
+    margin-top: 10px !important;
+  }
+  .p-\[30em\] {
+    padding: 30em;
+  }
+  .w-\[51vw\] {
+    width: 51vw;
+  }

--- a/test/processor/__snapshots__/interpret.test.ts.yml
+++ b/test/processor/__snapshots__/interpret.test.ts.yml
@@ -60,6 +60,9 @@ Tools / interpret important / important / 0: |-
     color: rgba(110, 231, 183, var(--tw-text-opacity)) !important;
   }
 Tools / interpret square brackets / square brackets / 0: |-
+  .m-\[-11rem\] {
+    margin: -11rem;
+  }
   .\!mt-\[10px\] {
     margin-top: 10px !important;
   }

--- a/test/processor/interpret.test.ts
+++ b/test/processor/interpret.test.ts
@@ -23,4 +23,10 @@ describe('Interpretation Mode', () => {
     expect(result.ignored.length).toEqual(0);
     expect(result.styleSheet.build()).toMatchSnapshot('important');
   });
+
+  it('interpret square brackets', () => {
+    const result = processor.interpret('p-[30em] !mt-[10px] w-[51vw]');
+    expect(result.ignored.length).toEqual(0);
+    expect(result.styleSheet.build()).toMatchSnapshot('square brackets');
+  });
 });

--- a/test/processor/interpret.test.ts
+++ b/test/processor/interpret.test.ts
@@ -25,7 +25,7 @@ describe('Interpretation Mode', () => {
   });
 
   it('interpret square brackets', () => {
-    const result = processor.interpret('p-[30em] !mt-[10px] w-[51vw]');
+    const result = processor.interpret('p-[30em] !mt-[10px] w-[51vw] m-[-11rem]');
     expect(result.ignored.length).toEqual(0);
     expect(result.styleSheet.build()).toMatchSnapshot('square brackets');
   });

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -86,6 +86,9 @@ describe('Tools', () => {
     expect(isSize('30vw')).toBeTrue();
     expect(isSize('30ch')).toBeTrue();
     expect(isSize('30ex')).toBeTrue();
+    expect(isSize('-30vw')).toBeTrue();
+    expect(isSize('-30ch')).toBeTrue();
+    expect(isSize('-30ex')).toBeTrue();
   });
 
   it('isSpace', () => {


### PR DESCRIPTION
As discussed in https://github.com/windicss/windicss/discussions/181#discussioncomment-514698

This PR enabled Tailwind JIT compatible "square brackets" syntax (credit to tailwind jit). It makes a thing like `p-[2em]` just works as `p-2em`.

While this PR only introduces the support for "square brackets", but not the configure to disabled the implicitly one. Which should be fairly easy to implement, but I am not sure how to name the field nor make it flexible enough for future needs. Proposals here

Proposal A

```ts
// windicss
export default {
  autoInfer: 'explict-only' | false | true
}
```

Proposal B

```ts
// windicss
export default {
  autoInfer: {
    strict: true,
    units: ['em', 'px'] // only enabled a few units
  }
}
```

Proposal C

```ts
// windicss
export default {
  strictAutoInfer: true
}
```

If we can find the best way to do that, I am happy to implement it in this PR. Or we can have the support first then think about the way to disabled implicitly auto infer later.