### PR TITLE
fix: apply --tw-space-*-reverse to child

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -275,8 +275,16 @@ function margin(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://tailwindcss.com/docs/space
 function space(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw === 'space-x-reverse') return new Property('--tw-space-x-reverse', '1').updateMeta({ type: 'utilities', corePlugin: true, group: 'space', order: pluginOrder['space'] + 6 });
-  if (utility.raw === 'space-y-reverse') return new Property('--tw-space-y-reverse', '1').updateMeta({ type: 'utilities', corePlugin: true, group: 'space', order: pluginOrder['space'] + 5 });
+  if (utility.raw === 'space-x-reverse') {
+    return new Style(utility.class, [
+      new Property('--tw-space-x-reverse', '1'),
+    ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta({ type: 'utilities', corePlugin: true, group: 'space', order: pluginOrder['space'] + 6 });
+  }
+  if (utility.raw === 'space-y-reverse') {
+    return new Style(utility.class, [
+      new Property('--tw-space-y-reverse', '1'),
+    ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta({ type: 'utilities', corePlugin: true, group: 'space', order: pluginOrder['space'] + 5 });
+  }
   const value = utility.handler
     .handleStatic(theme('space'))
     .handleSpacing()

--- a/test/processor/__snapshots__/interpret.test.ts.yml
+++ b/test/processor/__snapshots__/interpret.test.ts.yml
@@ -1,3 +1,12 @@
+Tools / generated correct css for space-x-reverse / css / 0: |-
+  .space-y-4 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
+  .space-x-reverse > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 1;
+  }
 Tools / interpret / css / 1: |-
   .bg-cool-gray-300 {
     --tw-bg-opacity: 1;

--- a/test/processor/interpret.test.ts
+++ b/test/processor/interpret.test.ts
@@ -45,7 +45,7 @@ describe('Interpretation Mode', () => {
     const result = processor.interpret('space-x-reverse space-y-4');
     expect(result.styleSheet.build()).toMatchSnapshot('css');
   });
-  
+
   it('interpret screen variants', () => {
     const result = processor.interpret('md:p-1 <lg:p-2 @xl:p-3');
     expect(result.ignored.length).toEqual(0);

--- a/test/processor/interpret.test.ts
+++ b/test/processor/interpret.test.ts
@@ -40,4 +40,9 @@ describe('Interpretation Mode', () => {
     const result = processor.interpret('./constructor');
     expect(result.ignored.length).toEqual(1);
   });
+
+  it('generated correct css for space-x-reverse', () => {
+    const result = processor.interpret('space-x-reverse space-y-4');
+    expect(result.styleSheet.build()).toMatchSnapshot('css');
+  });
 });


### PR DESCRIPTION
For example when you have `.space-y-4` and `.space-y-reverse`, the style below will be used.

```css
.space-y-4 > :not([hidden]) ~ :not([hidden]) {
    --tw-space-y-reverse: 0;
    margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
}
.space-y-reverse {
    --tw-space-y-reverse: 1;
}
```

`--tw-space-y-reverse: 1` will not be applied.

This PR changes `.space-y-reverse`'s style to below.

```css
.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
    --tw-space-y-reverse: 1;
}
```

This will fix `.space-x-reverse` and `.space-y-reverse` which are not working for now.
