### PR TITLE
fix: import relative path in lib/utilites/handler.ts

### DIFF
--- a/src/lib/utilities/handler.ts
+++ b/src/lib/utilities/handler.ts
@@ -13,10 +13,9 @@ import {
   flatColors,
 } from '../../utils/tools';
 
-import type { colorCallback, colorObject } from '../../interfaces';
+import type { colorCallback, colorObject, Handlers } from '../../interfaces';
 
-export type 
-  = {
+export type Handler = {
   utility: Utility
   value?: string
   _amount: string
@@ -80,9 +79,7 @@ export type
 
 export type HandlerCreator = (utility: Utility, value?: string | undefined, color?: colorCallback | undefined) => Handler;
 
-export function createHandler(handlers: 
-                               
-                               = { static: true }): HandlerCreator {
+export function createHandler(handlers: Handlers = { static: true }): HandlerCreator {
   return (utility: Utility, value?: string, color?: colorCallback) => {
     const handler: Handler = {
       utility,

--- a/src/lib/utilities/handler.ts
+++ b/src/lib/utilities/handler.ts
@@ -12,7 +12,7 @@ import {
   negateValue,
   flatColors,
 } from '../../utils/tools';
-import type { colorCallback, colorObject } from 'src/interfaces';
+import type { colorCallback, colorObject } from '../../interfaces';
 
 
 


### PR DESCRIPTION
When use example config

```ts
// windi.config.ts
import { defineConfig } from 'windicss/helpers'

export default defineConfig({
  /* configurations... */
})
```

build to javascript throw error

```bash
node_modules/windicss/types/lib/utilities/handler.d.ts:2:49 - error TS2307: Cannot find module 'src/interfaces' or its corresponding type declarations.

2 import type { colorCallback, colorObject } from 'src/interfaces';
```