### PR TITLE
fix: update condition for end group in ClassParser

### DIFF
--- a/src/utils/parser/class.ts
+++ b/src/utils/parser/class.ts
@@ -16,6 +16,7 @@ export default class ClassParser {
 
   private _handle_group(removeDuplicated = true): Element[] {
     if (!this.classNames) return [];
+    let preChar;
     let char;
     let group;
     let func;
@@ -66,7 +67,8 @@ export default class ClassParser {
         insideSquareBracket = true;
         break;
       case '(':
-        if (this.classNames.charAt(this.index - 1) === '-') {
+        preChar = this.classNames.charAt(this.index - 1);
+        if (preChar === '-' || (!ignoreSpace && preChar === ' ')) {
           ignoreBracket = true;
         } else if (ignoreSpace) {
           group = this._handle_group();


### PR DESCRIPTION
Sometimes there are has parenthesis in expressions when we use template syntax.

For example:

```html
<div class="text-black bg-white {{ ( conditionA || conditionB ) ? 'flex' : 'block' }}"></div>
```

When we use CLI interpretation mode.

Classname parse will end early.
