### PR TITLE
chore: drop node v15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 15.x]
+        node-version: [12.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Nodejs v15 is EOL on June 1st.

https://github.com/nodejs/Release#release-schedule