### PR TITLE
fix: data uris without quotes and escaping

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -227,18 +227,35 @@ export function searchPropEnd(text: string, startIndex = 0): number {
   let output = -1;
   let openSingleQuote = false;
   let openDoubleQuote = false;
+  let openBracket = false;
+  let isEscaped = false;
   while (index < text.length) {
     switch (text.charAt(index)) {
+    case '\\':
+      isEscaped = !isEscaped;
+      break;
     case '\'':
-      if (text.charAt(index - 1) !== '\\') openSingleQuote = !openSingleQuote;
+      if (!openDoubleQuote && !openBracket && !isEscaped) openSingleQuote = !openSingleQuote;
+      isEscaped = false;
       break;
     case '"':
-      if (text.charAt(index - 1) !== '\\') openDoubleQuote = !openDoubleQuote;
+      if (!openSingleQuote && !openBracket && !isEscaped) openDoubleQuote = !openDoubleQuote;
+      isEscaped = false;
+      break;
+    case '(':
+      if (!openBracket && !openSingleQuote && !openDoubleQuote && !isEscaped) openBracket = true;
+      isEscaped = false;
+      break;
+    case ')':
+      if (openBracket && !isEscaped) openBracket = false;
+      isEscaped = false;
       break;
     case ';':
-      if (openSingleQuote === false && openDoubleQuote === false) output = index;
+      if (!isEscaped && !openSingleQuote && !openDoubleQuote && !openBracket) output = index;
+      isEscaped = false;
       break;
     default:
+      isEscaped = false;
       break;
     }
     if (output !== -1) break;

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -232,6 +232,11 @@ describe('Tools', () => {
   it('search property end', () => {
     expect(searchPropEnd('font-family: "iconfont";')).toEqual(23);
     expect(searchPropEnd(String.raw`src: url('data:application/x-font-woff2;charset=utf-8;base64,d09GMgABAAAAAAXEAAsAAAAACy') format('woff2');`)).toEqual(105);
+    expect(searchPropEnd(String.raw`src: url(data:application/x-font-woff2;charset=utf-8;base64,d09GMgABAAAAAAXEAAsAAAAACy) format('woff2');`)).toEqual(103);
+    expect(searchPropEnd(String.raw`content: "')\"(";`)).toEqual(16);
+    expect(searchPropEnd(String.raw`content: '")\'(';`)).toEqual(16);
+    expect(searchPropEnd(String.raw`content: '\\';`)).toEqual(13);
+    expect(searchPropEnd(String.raw`content: ";";`)).toEqual(12);
   });
 
   it('search not escape', () => {


### PR DESCRIPTION
fixes #364
and also fixes some escaping issues like
```css
.some-class:after {
  content: '\\';
}
```
or
```css
.some-class {
  content: "'";
}
```