### PR TITLE
fix: add sky color

### DIFF
--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -9,6 +9,7 @@ type Colors =
   | 'indigo'
   | 'blue'
   | 'lightBlue'
+  | 'sky'
   | 'cyan'
   | 'teal'
   | 'emerald'
@@ -119,6 +120,18 @@ export const colors: DefaultColors =  {
     900: '#1e3a8a',
   },
   lightBlue: {
+    50: '#f0f9ff',
+    100: '#e0f2fe',
+    200: '#bae6fd',
+    300: '#7dd3fc',
+    400: '#38bdf8',
+    500: '#0ea5e9',
+    600: '#0284c7',
+    700: '#0369a1',
+    800: '#075985',
+    900: '#0c4a6e',
+  },
+  sky: {
     50: '#f0f9ff',
     100: '#e0f2fe',
     200: '#bae6fd',


### PR DESCRIPTION
Simply added sky color which actually is `lightBlue` renamed. `lightBlue` values have been left intact as is.