### PR TITLE
feat: add variant for the `::file-selector-button` pseudo-element

### DIFF
--- a/src/config/order.ts
+++ b/src/config/order.ts
@@ -43,6 +43,7 @@ export const variantOrder = [
   'after',
   'first-letter',
   'first-line',
+  'file-selector-button',
   'selection',
   'svg',
   'all',

--- a/src/lib/variants/state.ts
+++ b/src/lib/variants/state.ts
@@ -59,6 +59,7 @@ export function generateStates (
     after: () => new Style().pseudoElement('after'),
     'first-letter': () => new Style().pseudoElement('first-letter'),
     'first-line': () => new Style().pseudoElement('first-line'),
+    'file-selector-button': () => new Style().pseudoElement('file-selector-button'),
     selection: () => new Style().pseudoElement('selection'),
 
     svg: () => new Style().child('svg'),

--- a/test/processor/__snapshots__/variant.test.ts.yml
+++ b/test/processor/__snapshots__/variant.test.ts.yml
@@ -83,6 +83,7 @@ Tools / generate states / all / 0: |-
     "after": ".test::after {\n  background: #1C1C1E;\n}",
     "first-letter": ".test::first-letter {\n  background: #1C1C1E;\n}",
     "first-line": ".test::first-line {\n  background: #1C1C1E;\n}",
+    "file-selector-button": ".test::file-selector-button {\n  background: #1C1C1E;\n}",
     "selection": ".test::selection {\n  background: #1C1C1E;\n}",
     "svg": ".test svg {\n  background: #1C1C1E;\n}",
     "all": ".test * {\n  background: #1C1C1E;\n}",

--- a/test/processor/resolve.test.ts
+++ b/test/processor/resolve.test.ts
@@ -28,12 +28,12 @@ describe('Resolve Tests', () => {
       'not-only-of-type',  'even',             'odd',
       'even-of-type',      'odd-of-type',      'root',
       'empty',             'before',           'after',
-      'first-letter',      'first-line',       'selection',
-      'svg',               'all',              'children',
-      'siblings',          'sibling',          'ltr',
-      'rtl',               'group-hover',      'group-focus',
-      'group-active',      'group-visited',    'motion-safe',
-      'motion-reduce',
+      'first-letter',      'first-line',       'file-selector-button',
+      'selection',         'svg',              'all',
+      'children',          'siblings',         'sibling',
+      'ltr',               'rtl',              'group-hover',
+      'group-focus',       'group-active',     'group-visited',
+      'motion-safe',       'motion-reduce',
     ];
     const themeVariants = [ '@dark', '@light', '.dark', '.light', 'dark', 'light' ];
 


### PR DESCRIPTION
This PR adds a variant for the [`::file-selector-button`](https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button)  pseudo element.

I think I've added to the relevant tests but feel free to point out any others that are required.

Might be worth adding the prefixed `::-webkit-file-upload-button` and maybe even `::-ms-browse` to get browser support from 78 to 95+, but I'm not sure how to go about doing that. I can see I maybe need to add a function in the helpers file but not sure where it would be called from?