### PR TITLE
fix: Typo in animation-iteration-count breaks animation repeat utilities

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1259,7 +1259,7 @@ function animation(utility: Utility, { theme, config }: PluginUtils): Output {
       ?.updateMeta('utilities', 'animation', pluginOrder.animation, 22, true);
   }
   const animateIterationCount = utility.handler.handleBody(theme('animationIterationCount')).handleNumber(0, undefined, 'int').handleSquareBrackets().value;
-  if (animateIterationCount) return new Property(['-webkit-animation-iteration-count', 'aniamtion-iteration-count'], animateIterationCount).updateMeta('utilities', 'animation', pluginOrder.animation, 23, true);
+  if (animateIterationCount) return new Property(['-webkit-animation-iteration-count', 'animation-iteration-count'], animateIterationCount).updateMeta('utilities', 'animation', pluginOrder.animation, 23, true);
   const animations = toType(theme('animation'), 'object') as { [key: string]: string | { [key: string]: string } };
   if (Object.keys(animations).includes(body)) {
     let value = animations[body];

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -247,23 +247,23 @@ Tools / animation / animation / 0: |-
 Tools / animation iteration count / animationIterationCount / 0: |-
   .animate-loop {
     -webkit-animation-iteration-count: infinite;
-    aniamtion-iteration-count: infinite;
+    animation-iteration-count: infinite;
   }
   .animate-repeat-1 {
     -webkit-animation-iteration-count: 1;
-    aniamtion-iteration-count: 1;
+    animation-iteration-count: 1;
   }
   .animate-repeat-12 {
     -webkit-animation-iteration-count: 12;
-    aniamtion-iteration-count: 12;
+    animation-iteration-count: 12;
   }
   .animate-repeat-24 {
     -webkit-animation-iteration-count: 24;
-    aniamtion-iteration-count: 24;
+    animation-iteration-count: 24;
   }
   .animate-repeat-\[13\] {
     -webkit-animation-iteration-count: 13;
-    aniamtion-iteration-count: 13;
+    animation-iteration-count: 13;
   }
 Tools / animation order / transition / 0: |-
   @keyframes flash {
@@ -306,7 +306,7 @@ Tools / animation order / transition / 0: |-
   }
   .animate-loop {
     -webkit-animation-iteration-count: infinite;
-    aniamtion-iteration-count: infinite;
+    animation-iteration-count: infinite;
   }
 Tools / animation static utilities / animationStatic / 0: |-
   .animated {


### PR DESCRIPTION
### Description 📖 

This pull request fixes a typo in the `animateIterationCount` utility that causes the generated CSS to be incompatible with non-Webkit browsers.

#### Before

```css
.animate {
    -webkit-animation-iteration-count: 1;
    aniamtion-iteration-count: 1
}
```

#### After

```css
.animate {
    -webkit-animation-iteration-count: 1;
    animation-iteration-count: 1
}
```