### PR TITLE
fix: Container utilities should only output standard min-width rules

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -6,6 +6,7 @@ import { linearGradient, minMaxContent } from '../../utils/style/prefixer';
 import {
   generatePlaceholder,
   generateFontSize,
+  isString,
   expandDirection,
 } from '../../utils/helpers';
 
@@ -41,6 +42,7 @@ function container(utility: Utility, { theme }: PluginUtils): Output {
     const screens = toType(theme('container.screens', theme('screens')), 'object');
 
     for (const [screen, size] of Object.entries(screens)) {
+      if (!isString(size)) continue;
       const props = [new Property('max-width', `${size}`)];
       const padding = theme(`container.padding.${screen}`);
       if (padding && typeof padding === 'string') {

--- a/test/assets/windi.plugin.config.js
+++ b/test/assets/windi.plugin.config.js
@@ -9,7 +9,6 @@ module.exports = {
       md: '768px',
       lg: '976px',
       xl: '1440px',
-      print: { raw: 'print' },
     },
     colors: {
       gray: colors.coolGray,

--- a/test/assets/windi.plugin.config.js
+++ b/test/assets/windi.plugin.config.js
@@ -9,6 +9,7 @@ module.exports = {
       md: '768px',
       lg: '976px',
       xl: '1440px',
+      print: { raw: 'print' },
     },
     colors: {
       gray: colors.coolGray,

--- a/test/processor/__snapshots__/config.test.ts.yml
+++ b/test/processor/__snapshots__/config.test.ts.yml
@@ -139,6 +139,16 @@ Tools / confuses color with font-size if keys are the same / css / 0: |-
     --tw-text-opacity: 1;
     color: rgba(89, 174, 144, var(--tw-text-opacity));
   }
+Tools / container with screens / css / 0: |-
+  .container {
+    width: 100%;
+  }
+  @media print {
+    .print\:bg-black {
+      --tw-bg-opacity: 1;
+      background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
+    }
+  }
 Tools / dashify / css / 0: |-
   .foo {
     --tw-bg-opacity: 1;

--- a/test/processor/config.test.ts
+++ b/test/processor/config.test.ts
@@ -537,4 +537,16 @@ describe('Config', () => {
     });
     expect(processor.interpret('bg-transparent bg-primary bg-primary-focus text-primary-content').styleSheet.build()).toMatchSnapshot('css');
   });
+
+  // #402
+  it('container with screens', () => {
+    const processor = new Processor({
+      theme: {
+        screens: {
+          print: { raw: 'print' },
+        },
+      },
+    });
+    expect(processor.interpret('print:bg-black container').styleSheet.build()).toMatchSnapshot('css');
+  });
 });


### PR DESCRIPTION
### Description 📖 

This pull request fixes a bug in the [`container`](https://windicss.org/utilities/container.html#container) utility which was causing custom breakpoints to be rendered incorrectly.

### The Bug 🐞

For example, when using a custom breakpoint such as `min/max` or `raw`:

```
import { defineConfig } from 'vite-plugin-windicss'

export default defineConfig({
  theme: {
    extend: {
      screens: {
        print: { raw: 'print' },
      },
  },
})  
```

it would generate invalid CSS:

```css
@media (min-width: [object Object]) {
    .container {
        max-width:[object Object]
    }
}
```

### Notes ✏️

Supporting `min/max` or `raw` entrypoints would not make sense for the [`container`](https://windicss.org/utilities/container.html#container) utility, as it's purpose is to simplify layout when using a mobile-first approach.