### PR TITLE
fix: Incorrect duration and animate utilities (close #404)

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1182,6 +1182,8 @@ function opacity(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/transitions.html#transition-property
 function transition(utility: Utility, { theme }: PluginUtils): Output {
+  if (!utility.raw.startsWith('transition'))
+    return;
   const body = utility.body;
   const props = toType(theme('transitionProperty'), 'object') as { [key: string]: string };
   for (const [key, value] of Object.entries(props)) {
@@ -1200,6 +1202,8 @@ function transition(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/transitions.html#transition-duration
 function duration(utility: Utility, { theme }: PluginUtils): Output {
+  if (!utility.raw.startsWith('duration-'))
+    return;
   return utility.handler
     .handleStatic(theme('transitionDuration'))
     .handleSquareBrackets()
@@ -1232,6 +1236,8 @@ function delay(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/behaviors.html#animation
 function animation(utility: Utility, { theme, config }: PluginUtils): Output {
+  if (!utility.raw.startsWith('animate-'))
+    return;
   const body = utility.body;
   if (utility.raw.startsWith('animate-ease')) {
     return utility.clone(utility.raw.slice(8)).handler

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -785,6 +785,7 @@ Tools / content utilities / css / 0: |-
     content: attr(value);
   }
 Tools / content utilities false / css / 0: ''
+Tools / false duration and animate utilities / transition / 0: ''
 Tools / fill-none and stroke-none is wrong / css / 0: |-
   .fill-none {
     fill: none;

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -364,7 +364,7 @@ describe('Utilities', () => {
     `).styleSheet.build()).toMatchSnapshot('transition');
   });
 
-  // https://github.com/windicss/vite-plugin-windicss/issues/213
+  // #404
   it('false duration and animate utilities', () => {
     expect(processor.interpret(`
       <animate

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -364,6 +364,17 @@ describe('Utilities', () => {
     `).styleSheet.build()).toMatchSnapshot('transition');
   });
 
+  // https://github.com/windicss/vite-plugin-windicss/issues/213
+  it('false duration and animate utilities', () => {
+    expect(processor.interpret(`
+      <animate
+      <transition
+      .duration
+      duration
+      duration.value
+    `).styleSheet.build()).toMatchSnapshot('transition');
+  });
+
   it('fill-none and stroke-none is wrong', () => {
     expect(processor.interpret('fill-none stroke-none').styleSheet.build()).toMatchSnapshot('css');
   });


### PR DESCRIPTION
### Description 📖 

This pull request fixes the problems described in #404.

Added a test that ensures these invalid usages do not generate CSS rules.

### Background 📜 

It seems that processing `<` tokens opened up the door for a new category of bugs in utilities that were created prior to the change supporting `<sm` and similar variants. A similar bug is #403.

Perhaps instead of only fixing it at the utility level on a case-by-case basis, these tokens should __not__ be interpreted as utilities in the first place:

```js
// extract.ts line 61
const matches = !className.startsWith('<') && className.match(/\w+/);
```

However, the `duration.value` case suggests that the regex in the plugin utils should be more strict, as `.` should only occur if there's also a `-` in the token, as in `ml-1.5`. Am I missing a case here?

### Test Case

#### Before

```css
  .\<transition {
    -webkit-transition-property: background-color, border-color, color, fill, stroke, opacity, -webkit-box-shadow, -webkit-transform, filter, backdrop-filter;
    -o-transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, -webkit-box-shadow, transform, -webkit-transform, filter, backdrop-filter;
    -webkit-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
    -o-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
    -webkit-transition-duration: 150ms;
    -o-transition-duration: 150ms;
    transition-duration: 150ms;
  }
  .\.duration {
    -webkit-transition-duration: 150ms;
    -o-transition-duration: 150ms;
    transition-duration: 150ms;
  }
  .duration {
    -webkit-transition-duration: 150ms;
    -o-transition-duration: 150ms;
    transition-duration: 150ms;
  }
  .duration\.value {
    -webkit-transition-duration: 150ms;
    -o-transition-duration: 150ms;
    transition-duration: 150ms;
  }
  .\<animate {
    -webkit-animation-iteration-count: 1;
    animation-iteration-count: 1;
  }
```

#### After

No CSS rules
