### PR TITLE
feat: support for parsing array of style objects, fix #439

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1060,7 +1060,11 @@ export class Processor {
     const layer = options.layer ?? 'utilities';
     const order = layerOrder[layer] + 1;
     for (const [key, value] of Object.entries(utilities)) {
-      const styles = Style.generate(key.startsWith('.') && options.respectPrefix ? this.prefix(key) : key, value);
+      let propertyValue = value;
+      if (Array.isArray(value)) {
+        propertyValue = Object.assign({}, ...value);
+      }
+      const styles = Style.generate(key.startsWith('.') && options.respectPrefix ? this.prefix(key) : key, propertyValue);
       if (options.layer) styles.forEach(style => style.updateMeta(layer, 'plugin', order, ++this._cache.count));
       if (options.respectImportant && this._config.important) styles.forEach(style => style.important = true);
       let className = guessClassName(key);
@@ -1172,7 +1176,11 @@ export class Processor {
   addBase(baseStyles: DeepNestObject): Style[] {
     let output: Style[] = [];
     for (const [key, value] of Object.entries(baseStyles)) {
-      const styles = Style.generate(key, value).map(i => i.updateMeta('base', 'plugin', 10, ++this._cache.count));
+      let propertyValue = value;
+      if (Array.isArray(value)) {
+        propertyValue = Object.assign({}, ...value);
+      }
+      const styles = Style.generate(key, propertyValue).map(i => i.updateMeta('base', 'plugin', 10, ++this._cache.count));
       this._replaceStyleVariants(styles);
       this._addPluginProcessorCache('preflights', key, styles);
       output = [...output, ...styles];

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1132,7 +1132,11 @@ export class Processor {
     const layer = options.layer ?? 'components';
     const order = layerOrder[layer] + 1;
     for (const [key, value] of Object.entries(components)) {
-      const styles = Style.generate(key.startsWith('.') && options.respectPrefix ? this.prefix(key): key, value);
+      let propertyValue = value;
+      if (Array.isArray(value)) {
+        propertyValue = Object.assign({}, ...value);
+      }
+      const styles = Style.generate(key.startsWith('.') && options.respectPrefix ? this.prefix(key) : key, propertyValue);
       styles.forEach(style => style.updateMeta(layer, 'plugin', order, ++this._cache.count));
       if (options.respectImportant && this._config.important) styles.forEach(style => style.important = true);
       let className = guessClassName(key);

--- a/src/utils/style/base.ts
+++ b/src/utils/style/base.ts
@@ -249,10 +249,14 @@ export class Style {
     let output: Style[] = [];
 
     for (const [key, value] of Object.entries(property ?? {})) {
-      if (typeof value === 'string') {
-        root.add(new Property(camelToDash(key), value));
-      } else if (Array.isArray(value)) {
-        value.map(i => root?.add(new Property(camelToDash(key), i)));
+      let propertyValue = value;
+      if (Array.isArray(propertyValue) && propertyValue.every(e => typeof e === 'object')) {
+        propertyValue = Object.assign({}, ...propertyValue);
+      }
+      if (typeof propertyValue === 'string') {
+        root.add(new Property(camelToDash(key), propertyValue));
+      } else if (Array.isArray(propertyValue)) {
+        propertyValue.map(i => root?.add(new Property(camelToDash(key), i)));
       } else {
         const wrap = deepCopy(root);
         wrap.property = [];
@@ -285,7 +289,7 @@ export class Style {
             }
           }
         }
-        output = output.concat(Style.generate(key.startsWith('@') ? undefined : key, value, child));
+        output = output.concat(Style.generate(key.startsWith('@') ? undefined : key, propertyValue, child));
       }
     }
     if (root.property.length > 0) output.unshift(root);

--- a/test/interface/__snapshots__/plugin.test.ts.yml
+++ b/test/interface/__snapshots__/plugin.test.ts.yml
@@ -1,10 +1,10 @@
-Tools / addComponents nested selectors / css / 0: |-
+Plugin Method / addComponents nested selectors / css / 0: |-
   .card.compact .card-body {
     font-size: .875rem;
     line-height: 1.25rem;
     padding: 1rem;
   }
-Tools / addComponents order / css / 0: |-
+Plugin Method / addComponents order / css / 0: |-
   [data-theme=dark] {
     --p: 259 94% 61%;
   }
@@ -16,7 +16,7 @@ Tools / addComponents order / css / 0: |-
   [data-theme=light] {
     --p: 259 94% 51%;
   }
-Tools / addComponents with attribute selectors / css / 0: |-
+Plugin Method / addComponents with attribute selectors / css / 0: |-
   btn-disabled, .btn[disabled] {
     --tw-bg-opacity: 1;
     --tw-bg-opacity: 0.2;
@@ -26,7 +26,7 @@ Tools / addComponents with attribute selectors / css / 0: |-
     --tw-text-opacity: 0.2;
     color: hsla(var(--bc,215 28% 17%)/var(--tw-text-opacity));
   }
-Tools / variants not cleared when plugin loaded / css / 0: |-
+Plugin Method / variants not cleared when plugin loaded / css / 0: |-
   .variant .variant\:text-black {
     --tw-text-opacity: 1;
     color: rgba(0, 0, 0, var(--tw-text-opacity));

--- a/test/processor/__snapshots__/plugin.test.ts.yml
+++ b/test/processor/__snapshots__/plugin.test.ts.yml
@@ -144,3 +144,17 @@ Tools / interpret order should follow add components order / css / 0: |-
     border-radius: .5rem;
     font-weight: 700;
   }
+Tools / properties as array of style objects / css / 0: |-
+  @media (min-width:1024px) {
+    .btn {
+      color: red;
+      border: 1rem;
+    }
+  }
+Tools / properties as array of style objects / css / 1: |-
+  @media (min-width:1024px) {
+    .btn-side {
+      color: white;
+      border: 2rem;
+    }
+  }

--- a/test/processor/__snapshots__/plugin.test.ts.yml
+++ b/test/processor/__snapshots__/plugin.test.ts.yml
@@ -1,31 +1,45 @@
-Tools / add duplicated components / css / 0: |-
+'Plugin Method / add components containing array of style objects #439 / css / 0': |-
+  @media (min-width:1024px) {
+    .btn {
+      color: red;
+      border: 1rem;
+    }
+  }
+'Plugin Method / add components containing array of style objects #439 / css / 1': |-
+  @media (min-width:1024px) {
+    .btn-side {
+      color: white;
+      border: 2rem;
+    }
+  }
+Plugin Method / add duplicated components / css / 0: |-
   .btn {
     padding: .5rem 1rem;
     border-radius: .25rem;
     font-weight: 600;
   }
-Tools / add duplicated utilities / css / 0: |-
+Plugin Method / add duplicated utilities / css / 0: |-
   .btn {
     padding: .5rem 1rem;
     border-radius: .25rem;
     font-weight: 600;
   }
-Tools / add multi utilities / a / 1: |-
+Plugin Method / add multi utilities / a / 1: |-
   .a {
     padding: .5rem 1rem;
     border-radius: .25rem;
   }
-Tools / add multi utilities / b / 2: |-
+Plugin Method / add multi utilities / b / 2: |-
   .b:hover {
     padding: .5rem 1rem;
     border-radius: .25rem;
   }
-Tools / add multi utilities / preflight / 0: |-
+Plugin Method / add multi utilities / preflight / 0: |-
   [type='button'] {
     padding: .5rem 1rem;
     border-radius: .25rem;
   }
-Tools / add nest class name / css / 0: |-
+Plugin Method / add nest class name / css / 0: |-
   .btn.loading:before {
     border-radius: 9999px;
     border-width: 2px;
@@ -37,7 +51,7 @@ Tools / add nest class name / css / 0: |-
     content: "";
     border-color: transparent currentColor currentColor transparent;
   }
-Tools / add pseudo components / css / 0: |-
+Plugin Method / add pseudo components / css / 0: |-
   .btn {
     padding: .5rem 1rem;
     border-radius: .25rem;
@@ -52,7 +66,7 @@ Tools / add pseudo components / css / 0: |-
       }
     }
   }
-Tools / add pseudo utilities / css / 0: |-
+Plugin Method / add pseudo utilities / css / 0: |-
   .btn {
     padding: .5rem 1rem;
     border-radius: .25rem;
@@ -78,7 +92,21 @@ Tools / add pseudo utilities / css / 0: |-
       }
     }
   }
-'Tools / addComponents #242 / css / 0': |-
+'Plugin Method / add utilities containing array of style objects #439 / css / 0': |-
+  @media (min-width:1024px) {
+    .btn {
+      color: red;
+      border: 1rem;
+    }
+  }
+'Plugin Method / add utilities containing array of style objects #439 / css / 1': |-
+  @media (min-width:1024px) {
+    .btn-side {
+      color: white;
+      border: 2rem;
+    }
+  }
+'Plugin Method / addComponents #242 / css / 0': |-
   .avatar>div {
     display: block;
     overflow: hidden;
@@ -95,7 +123,7 @@ Tools / add pseudo utilities / css / 0: |-
     display: block;
     overflow: hidden;
   }
-Tools / addComponents with non-class styles  / css / 0: |-
+Plugin Method / addComponents with non-class styles  / css / 0: |-
   [data-theme] {
     --active: #0099FF;
   }
@@ -115,24 +143,24 @@ Tools / addComponents with non-class styles  / css / 0: |-
     --on-frame: #808080;
     --on-frame-active: var(--on-primary);
   }
-Tools / addVariant modifySelectors / css / 0: |-
+Plugin Method / addVariant modifySelectors / css / 0: |-
   .disabled\:float-right:disabled {
     float: right;
   }
-Tools / addVariant pseudoClass / css / 1: |-
+Plugin Method / addVariant pseudoClass / css / 1: |-
   .hocus\:float-right:hover:focus {
     float: right;
   }
-Tools / addVariant pseudoClass / extend / 0: |-
+Plugin Method / addVariant pseudoClass / extend / 0: |-
   .float-right:hover:focus {
     float: right;
   }
-Tools / dump config / css / 0: |-
+Plugin Method / dump config / css / 0: |-
   .bg-nord0 {
     --tw-bg-opacity: 1;
     background-color: rgba(46, 52, 64, var(--tw-bg-opacity));
   }
-Tools / interpret order should follow add components order / css / 0: |-
+Plugin Method / interpret order should follow add components order / css / 0: |-
   .btn {
     padding: .5rem 1rem;
   }
@@ -143,18 +171,4 @@ Tools / interpret order should follow add components order / css / 0: |-
   .btn-lg {
     border-radius: .5rem;
     font-weight: 700;
-  }
-Tools / properties as array of style objects / css / 0: |-
-  @media (min-width:1024px) {
-    .btn {
-      color: red;
-      border: 1rem;
-    }
-  }
-Tools / properties as array of style objects / css / 1: |-
-  @media (min-width:1024px) {
-    .btn-side {
-      color: white;
-      border: 2rem;
-    }
   }

--- a/test/processor/plugin.test.ts
+++ b/test/processor/plugin.test.ts
@@ -221,6 +221,19 @@ describe('Plugin Method', () => {
     expect(processor.interpret('btn').styleSheet.build()).toMatchSnapshot('css');
   });
 
+  it('properties as array of style objects', () => {
+    const a = {
+      '@media (min-width:1024px)': [
+        { '.btn': [{ color: 'red' }, { border: '1rem' }] },
+        { '.btn-side': { color: 'white', border: '2rem' } },
+      ],
+    };
+    const processor = new Processor();
+    processor.addComponents(a);
+    expect(processor.interpret('btn').styleSheet.build()).toMatchSnapshot('css');
+    expect(processor.interpret('btn-side').styleSheet.build()).toMatchSnapshot('css');
+  });
+
   it('interpret order should follow add components order', () => {
     const a = {
       '.btn': {

--- a/test/processor/plugin.test.ts
+++ b/test/processor/plugin.test.ts
@@ -104,6 +104,20 @@ describe('Plugin Method', () => {
     expect(processor.interpret('b').styleSheet.build()).toMatchSnapshot('b');
   });
 
+  it('add utilities containing array of style objects #439', () => {
+    const a = {
+      '@media (min-width:1024px)': [
+        { '.btn': [{ color: 'red' }, { border: '1rem' }] },
+        { '.btn-side': { color: 'white', border: '2rem' } },
+      ],
+    };
+    const processor = new Processor();
+    processor.addUtilities(a);
+    expect(processor.interpret('btn').styleSheet.build()).toMatchSnapshot('css');
+    expect(processor.interpret('btn-side').styleSheet.build()).toMatchSnapshot('css');
+  });
+
+
   it('addComponents', () => {
     const buttons = {
       '.btn': {
@@ -221,7 +235,7 @@ describe('Plugin Method', () => {
     expect(processor.interpret('btn').styleSheet.build()).toMatchSnapshot('css');
   });
 
-  it('properties as array of style objects', () => {
+  it('add components containing array of style objects #439', () => {
     const a = {
       '@media (min-width:1024px)': [
         { '.btn': [{ color: 'red' }, { border: '1rem' }] },
@@ -276,6 +290,17 @@ describe('Plugin Method', () => {
     });
 
     expect(processor.preflight(undefined, false, false, true).build()).toEqual('h1 {\n  font-size: 1.5rem;\n}\nh2 {\n  font-size: 1.25rem;\n}');
+  });
+
+  it('add base styles containing array of style objects #439', () => {
+    const a = {
+      'h1': [{ fontSize: '1.5rem' }, { lineHeight: '.2rem' }],
+      'h2': { fontSize: '1.5rem', lineHeight: '.2rem' },
+    };
+    const processor = new Processor();
+    const result = processor.addBase(a).map(i => i.build());
+    expect(result[0]).toEqual('h1 {\n  font-size: 1.5rem;\n  line-height: .2rem;\n}');
+    expect(result[1]).toEqual('h2 {\n  font-size: 1.5rem;\n  line-height: .2rem;\n}');
   });
 
   it('addVariant pseudoClass', () => {
@@ -371,7 +396,7 @@ describe('Plugin Method', () => {
   it('syntax for hex colors', () => {
     const processor = new Processor({
       plugins: [
-        plugin(function ({ addDynamic }) {
+        plugin(function({ addDynamic }) {
           addDynamic('bg', ({ Utility, Style, Property }) => {
             if (/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(Utility.body)) {
               return Style(Utility.class, [


### PR DESCRIPTION
This PR adds support for array of style objects. Currently without this support it breaks compilation during transformation of some of the plugins such as `daisyui` as described in #439.

I have added this support for `base`, `utilities` and `component` methods. I have also added tests and followed steps as described in the contributing guide.. This is my first PR on this repo, hence, looking forward to any comments.