### PR TITLE
fix: some fuzzy class names will also be incorrectly matched (close #484)

### DIFF
--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -58,8 +58,7 @@ export default function extract(
   }
 
   // handle dynamic base utilities
-  const matches = className.match(/\w+/);
-  const key = matches ? matches[0] : undefined;
+  const key = className.replace(/^-/, '').match(/^\w+/)?.[0];
   // eslint-disable-next-line no-prototype-builtins
   if (key && dynamicUtilities.hasOwnProperty(key)) {
     let style = dynamicUtilities[key](utility, processor.pluginUtils);

--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -68,8 +68,9 @@ function objectPosition(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/positioning.html#top-right-bottom-left
 function inset(utility: Utility, { theme }: PluginUtils): Output {
-  return utility.handler
-    .handleStatic(theme('inset'))
+  const handler = utility.handler.catchPrefix(/^-?(top|left|bottom|right|inset(-(x|y))?)/, true);
+  return handler
+    ?.handleStatic(theme('inset'))
     .handleSquareBrackets()
     .handleSpacing()
     .handleFraction()
@@ -84,8 +85,8 @@ function inset(utility: Utility, { theme }: PluginUtils): Output {
       case 'left':
         return new Property(utility.identifier, value).updateMeta('utilities', 'inset', pluginOrder.inset, 4, true);
       case 'inset':
-        if (utility.raw.match(/^-?inset-x/)) return new Property(['right', 'left'], value).updateMeta('utilities', 'inset', pluginOrder.inset, 3, true);
-        if (utility.raw.match(/^-?inset-y/)) return new Property(['top', 'bottom'], value).updateMeta('utilities', 'inset', pluginOrder.inset, 2, true);
+        if (handler.prefix?.endsWith('inset-x')) return new Property(['right', 'left'], value).updateMeta('utilities', 'inset', pluginOrder.inset, 3, true);
+        if (handler.prefix?.endsWith('inset-y')) return new Property(['top', 'bottom'], value).updateMeta('utilities', 'inset', pluginOrder.inset, 2, true);
         return new Property(['top', 'right', 'bottom', 'left'], value).updateMeta('utilities', 'inset', pluginOrder.inset, 1, true);
       }
     });
@@ -94,7 +95,8 @@ function inset(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/positioning.html#z-index
 function zIndex(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('zIndex'))
+    .catchPrefix(/^-?z/)
+    ?.handleBody(theme('zIndex'))
     .handleNumber(0, 99999, 'int')
     .handleNegative()
     .handleVariable()
@@ -106,19 +108,19 @@ function zIndex(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/flexbox.html#flex-grow
 // https://windicss.org/utilities/flexbox.html#flex-shrink
 function flex(utility: Utility, { theme }: PluginUtils): Output {
-  const className = utility.raw;
-  if (className.startsWith('flex-grow')) {
+  const handler = utility.handler;
+  if (handler.catchPrefix(/^flex-grow/, true)) {
     const map = toType(theme('flexGrow'), 'object') as { [key: string]: string };
-    const amount = className.replace(/flex-grow-?/, '') || 'DEFAULT';
-    if (Object.keys(map).includes(amount)) return new Property(['-webkit-box-flex', '-ms-flex-positive', '-webkit-flex-grow', 'flex-grow'], map[amount]).toStyle(utility.class).updateMeta('utilities', 'flexGrow', pluginOrder.flexGrow, 0, true);
-    return utility.handler.handleSquareBrackets().createProperty(['-webkit-box-flex', '-ms-flex-positive', '-webkit-flex-grow', 'flex-grow'])?.updateMeta('utilities', 'flexGrow', pluginOrder.flexGrow, 1, true);
-  } else if (className.startsWith('flex-shrink')) {
+    const amount = utility.raw.replace(/flex-grow-?/, '') || 'DEFAULT';
+    if (amount === 'DEFAULT' || handler.isStatic(map, amount)) return new Property(['-webkit-box-flex', '-ms-flex-positive', '-webkit-flex-grow', 'flex-grow'], map[amount]).toStyle(utility.class).updateMeta('utilities', 'flexGrow', pluginOrder.flexGrow, 0, true);
+    return handler.handleSquareBrackets().createProperty(['-webkit-box-flex', '-ms-flex-positive', '-webkit-flex-grow', 'flex-grow'])?.updateMeta('utilities', 'flexGrow', pluginOrder.flexGrow, 1, true);
+  } else if (handler.catchPrefix(/^flex-shrink/, true)) {
     const map = toType(theme('flexShrink'), 'object') as { [key: string]: string };
-    const amount = className.replace(/flex-shrink-?/, '') || 'DEFAULT';
-    if (Object.keys(map).includes(amount)) return new Property(['-ms-flex-negative', '-webkit-flex-shrink', 'flex-shrink'], map[amount]).toStyle(utility.class).updateMeta('utilities', 'flexShrink', pluginOrder.flexShrink, 0, true);
-    return utility.handler.handleSquareBrackets().createProperty(['-ms-flex-negative', '-webkit-flex-shrink', 'flex-shrink'])?.updateMeta('utilities', 'flexShrink', pluginOrder.flexShrink, 1, true);
+    const amount = utility.raw.replace(/flex-shrink-?/, '') || 'DEFAULT';
+    if (amount === 'DEFAULT' || handler.isStatic(map, amount)) return new Property(['-ms-flex-negative', '-webkit-flex-shrink', 'flex-shrink'], map[amount]).toStyle(utility.class).updateMeta('utilities', 'flexShrink', pluginOrder.flexShrink, 0, true);
+    return handler.handleSquareBrackets().createProperty(['-ms-flex-negative', '-webkit-flex-shrink', 'flex-shrink'])?.updateMeta('utilities', 'flexShrink', pluginOrder.flexShrink, 1, true);
   } else {
-    return utility.handler.handleStatic(theme('flex')).handleSquareBrackets().createStyle(utility.class, value => {
+    return handler.catchPrefix(/^flex/)?.handleStatic(theme('flex')).handleSquareBrackets().createStyle(utility.class, value => {
       value = value.trim();
       return [
         new Property('-webkit-box-flex', value.startsWith('0') || value === 'none' ? '0' : '1'),
@@ -131,7 +133,8 @@ function flex(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/positioning.html#order
 function order(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('order'))
+    .catchPrefix(/^-?order/)
+    ?.handleStatic(theme('order'))
     .handleNumber(1, 9999, 'int')
     .handleNegative()
     .handleVariable()
@@ -145,15 +148,16 @@ function order(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/grid.html#grid-template-columns
 // https://windicss.org/utilities/grid.html#grid-template-rows
 function gridTemplate(utility: Utility, { theme }: PluginUtils): Output {
-  const type = utility.raw.match(/^grid-rows-/) ? 'rows' : utility.raw.match(/^grid-cols-/) ? 'columns' : undefined;
-  if (!type) return;
-  const group = type === 'rows'? 'gridTemplateRows' : 'gridTemplateColumns';
-  return utility.handler
+  const handler = utility.handler.catchPrefix(/^grid-(rows|cols)/, true);
+  if (!handler) return;
+  const type = handler.prefix === 'grid-rows' ? 'rows' : 'columns';
+  const group = handler.prefix === 'grid-rows' ? 'gridTemplateRows': 'gridTemplateColumns';
+  return handler
     .handleStatic(theme(group))
     .handleSquareBrackets(i => i.replace(/\(.*?\)|,/g, (r) => r === ',' ? ' ' : r /* ignore content inside nested-brackets */ ))
     .createProperty(`grid-template-${type}`, (value) => value === 'none' ? 'none' : value)
     ?.updateMeta('utilities', group, pluginOrder[group], 1, true)
-  || utility.handler
+  || handler
     .handleNumber(1, undefined, 'int')
     .handleVariable()
     .createProperty(`grid-template-${type}`, (value) => `repeat(${value}, minmax(0, 1fr))`)
@@ -168,35 +172,31 @@ function gridColumn(utility: Utility, { theme }: PluginUtils): Output {
   // col span
   const spans = toType(theme('gridColumn'), 'object') as { [key: string]: string };
   if (Object.keys(spans).includes(body)) return new Property(['-ms-grid-column-span', 'grid-column'], spans[body]).updateMeta('utilities', 'gridColumn', pluginOrder.gridColumn, 1, true);
-  if (utility.raw.startsWith('col-span')) {
-    return utility.handler
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty(['-ms-grid-column-span', 'grid-column'], (value) => `span ${value} / span ${value}`)
-      ?.updateMeta('utilities', 'gridColumn', pluginOrder.gridColumn, 1, true);
-  }
-  // col end
-  if (utility.raw.startsWith('col-end')) {
-    return utility.handler
-      .handleStatic(theme('gridColumnEnd'))
-      .handleSquareBrackets()
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty('grid-column-end')
-      ?.updateMeta('utilities', 'gridColumnEnd', pluginOrder.gridColumnEnd, 1, true);
-  }
-  // col start
-  if (utility.raw.startsWith('col-start')) {
-    return utility.handler
-      .handleStatic(theme('gridColumnStart'))
-      .handleSquareBrackets()
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty('grid-column-start')
-      ?.updateMeta('utilities', 'gridColumnStart', pluginOrder.gridColumnStart, 1, true);
-  }
   return utility.handler
+    .catchPrefix(/^col-span/, true)
+    ?.handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty(['-ms-grid-column-span', 'grid-column'], (value) => `span ${value} / span ${value}`)
+    ?.updateMeta('utilities', 'gridColumn', pluginOrder.gridColumn, 1, true)
+  || utility.handler
+    .catchPrefix(/^col-end/, true)
+    ?.handleStatic(theme('gridColumnEnd'))
     .handleSquareBrackets()
+    .handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty('grid-column-end')
+    ?.updateMeta('utilities', 'gridColumnEnd', pluginOrder.gridColumnEnd, 1, true)
+  || utility.handler
+    .catchPrefix(/^col-start/, true)
+    ?.handleStatic(theme('gridColumnStart'))
+    .handleSquareBrackets()
+    .handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty('grid-column-start')
+    ?.updateMeta('utilities', 'gridColumnStart', pluginOrder.gridColumnStart, 1, true)
+  || utility.handler
+    .catchPrefix(/^col/)
+    ?.handleSquareBrackets()
     .createProperty(['-ms-grid-column-span', 'grid-column'], (value) => `span ${value} / span ${value}`)
     ?.updateMeta('utilities', 'gridColumn', pluginOrder.gridColumn, 1, true);
 }
@@ -209,35 +209,34 @@ function gridRow(utility: Utility, { theme }: PluginUtils): Output {
   // row span
   const spans = toType(theme('gridRow'), 'object') as { [key: string]: string };
   if (Object.keys(spans).includes(body)) return new Property(['-ms-grid-row-span', 'grid-row'], spans[body]).updateMeta('utilities', 'gridRow', pluginOrder.gridRow, 1, true);
-  if (utility.raw.startsWith('row-span')) {
-    return utility.handler
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty(['-ms-grid-row-span', 'grid-row'], (value: string) => `span ${value} / span ${value}`)
-      ?.updateMeta('utilities', 'gridRow', pluginOrder.gridRow, 2, true);
-  }
-  // row end
-  if (utility.raw.startsWith('row-end')) {
-    return utility.handler
-      .handleStatic(theme('gridRowEnd'))
-      .handleSquareBrackets()
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty('grid-row-end')
-      ?.updateMeta('utilities', 'gridRowEnd', pluginOrder.gridRowEnd, 1, true);
-  }
-  // row start
-  if (utility.raw.startsWith('row-start')) {
-    return utility.handler
-      .handleStatic(theme('gridRowStart'))
-      .handleSquareBrackets()
-      .handleNumber(1, undefined, 'int')
-      .handleVariable()
-      .createProperty('grid-row-start')
-      ?.updateMeta('utilities', 'gridRowStart', pluginOrder.gridRowStart, 1, true);
-  }
   return utility.handler
+    .catchPrefix(/^row-span/, true)
+    ?.handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty(['-ms-grid-row-span', 'grid-row'], (value: string) => `span ${value} / span ${value}`)
+    ?.updateMeta('utilities', 'gridRow', pluginOrder.gridRow, 2, true)
+  ||
+  utility.handler
+    .catchPrefix(/^row-end/, true)
+    ?.handleStatic(theme('gridRowEnd'))
     .handleSquareBrackets()
+    .handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty('grid-row-end')
+    ?.updateMeta('utilities', 'gridRowEnd', pluginOrder.gridRowEnd, 1, true)
+  ||
+  utility.handler
+    .catchPrefix(/^row-start/, true)
+    ?.handleStatic(theme('gridRowStart'))
+    .handleSquareBrackets()
+    .handleNumber(1, undefined, 'int')
+    .handleVariable()
+    .createProperty('grid-row-start')
+    ?.updateMeta('utilities', 'gridRowStart', pluginOrder.gridRowStart, 1, true)
+  ||
+  utility.handler
+    .catchPrefix(/^row/)
+    ?.handleSquareBrackets()
     .createProperty(['-ms-grid-row-span', 'grid-row'], (value: string) => `span ${value} / span ${value}`)
     ?.updateMeta('utilities', 'gridRow', pluginOrder.gridRow, 2, true);
 }
@@ -245,10 +244,11 @@ function gridRow(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/grid.html#grid-auto-columns
 // https://windicss.org/utilities/grid.html#grid-auto-rows
 function gridAuto(utility: Utility, { theme }: PluginUtils): Output {
-  const type = utility.raw.startsWith('auto-cols') ? 'columns' : utility.raw.startsWith('auto-rows') ? 'rows' : undefined;
-  if (!type) return;
-  const group = type === 'columns' ? 'gridAutoColumns' : 'gridAutoRows';
-  const value = utility.handler.handleStatic(theme(group)).value;
+  const handler = utility.handler.catchPrefix(/^auto-(rows|cols)/, true);
+  if (!handler) return;
+  const type = handler.prefix === 'auto-rows' ? 'rows' : 'columns';
+  const group = handler.prefix === 'auto-rows' ? 'gridAutoRows': 'gridAutoColumns';
+  const value = handler.handleStatic(theme(group)).value;
   if (value) {
     const prefixer = minMaxContent(value);
     if (typeof prefixer === 'string') return new Property(`grid-auto-${type}`, prefixer).updateMeta('utilities', group, pluginOrder[group], 1, true);
@@ -258,15 +258,16 @@ function gridAuto(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/grid.html#gap
 function gap(utility: Utility, { theme, config }: PluginUtils): Output {
-  return utility.handler
+  const handler = utility.handler.catchPrefix(/^gap(-(x|y))?/, true);
+  if (handler) return handler
     .handleStatic(theme('gap'))
     .handleSquareBrackets()
     .handleSpacing()
     .handleSize()
     .handleVariable()
     .callback(value => {
-      if (utility.raw.match(/^gap-x-/)) return new Property(config('prefixer') ? ['-webkit-column-gap', '-moz-column-gap', 'grid-column-gap', 'column-gap'] : 'column-gap', value).updateMeta('utilities', 'gap', pluginOrder.gap, 2, true);
-      if (utility.raw.match(/^gap-y-/)) return new Property(config('prefixer') ? ['-webkit-row-gap', '-moz-row-gap', 'grid-row-gap', 'row-gap'] : 'row-gap', value).updateMeta('utilities', 'gap', pluginOrder.gap, 3, true);
+      if (handler.prefix === 'gap-x') return new Property(config('prefixer') ? ['-webkit-column-gap', '-moz-column-gap', 'grid-column-gap', 'column-gap'] : 'column-gap', value).updateMeta('utilities', 'gap', pluginOrder.gap, 2, true);
+      if (handler.prefix === 'gap-y') return new Property(config('prefixer') ? ['-webkit-row-gap', '-moz-row-gap', 'grid-row-gap', 'row-gap'] : 'row-gap', value).updateMeta('utilities', 'gap', pluginOrder.gap, 3, true);
       return new Property(config('prefixer') ? ['grid-gap', 'gap'] : 'gap', value).updateMeta('utilities', 'gap', pluginOrder.gap, 1, true);
     });
 }
@@ -274,7 +275,8 @@ function gap(utility: Utility, { theme, config }: PluginUtils): Output {
 // https://windicss.org/utilities/spacing.html#padding
 function padding(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('padding'))
+    .catchPrefix(/^p(x|y|t|l|b|r)?/)
+    ?.handleStatic(theme('padding'))
     .handleSquareBrackets()
     .handleSpacing()
     .handleFraction()
@@ -292,7 +294,8 @@ function padding(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/spacing.html#margin
 function margin(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('margin'))
+    .catchPrefix(/^-?m(x|y|t|l|b|r)?/)
+    ?.handleStatic(theme('margin'))
     .handleSquareBrackets()
     .handleSpacing()
     .handleFraction()
@@ -320,57 +323,58 @@ function space(utility: Utility, { theme }: PluginUtils): Output {
       new Property('--tw-space-y-reverse', '1'),
     ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'space', pluginOrder.space, 5, true);
   }
-  return utility.handler
-    .handleStatic(theme('space'))
+  const handler = utility.handler;
+  return handler
+    .catchPrefix(/^-?space-(x|y)/, true)
+    ?.handleStatic(theme('space'))
     .handleSquareBrackets()
     .handleSpacing()
     .handleSize()
     .handleNegative()
     .handleVariable()
     .callback(value => {
-      if (utility.raw.match(/^-?space-x-/)) {
+      if (handler.prefix?.endsWith('space-x')) {
         return new Style(utility.class, [
           new Property('--tw-space-x-reverse', '0'),
           new Property('margin-right', `calc(${value} * var(--tw-space-x-reverse))`),
           new Property('margin-left', `calc(${value} * calc(1 - var(--tw-space-x-reverse)))`),
         ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'space', pluginOrder.space, (utility.raw.charAt(0) === '-' ? 4 : 2), true);
       }
-      if (utility.raw.match(/^-?space-y-/)) {
-        return new Style(utility.class, [
-          new Property('--tw-space-y-reverse', '0'),
-          new Property('margin-top', `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`),
-          new Property('margin-bottom', `calc(${value} * var(--tw-space-y-reverse))`),
-        ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'space', pluginOrder.space, (utility.raw.charAt(0) === '-' ? 3 : 1), true);
-      }
+      return new Style(utility.class, [
+        new Property('--tw-space-y-reverse', '0'),
+        new Property('margin-top', `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`),
+        new Property('margin-bottom', `calc(${value} * var(--tw-space-y-reverse))`),
+      ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'space', pluginOrder.space, (utility.raw.charAt(0) === '-' ? 3 : 1), true);
     });
 }
 
 // https://windicss.org/utilities/sizing.html#width
 // https://windicss.org/utilities/sizing.html#height
 function size(utility: Utility, { theme }: PluginUtils): Output {
+  const handler = utility.handler.catchPrefix(/^(w|h)/);
+  if (!handler) return;
   const name = utility.identifier === 'w' ? 'width' : 'height';
-  const body = utility.body;
   const sizes = toType(theme(name), 'object') as { [key: string]: string };
   // handle static
-  if (Object.keys(sizes).includes(body)) {
-    const value = sizes[body];
-    if (value === 'min-content') {
+  if (utility.body in sizes) {
+    switch (sizes[utility.body]) {
+    case 'min-content':
       return new Style(utility.class, [
         new Property(name, '-webkit-min-content'),
         new Property(name, '-moz-min-content'),
         new Property(name, 'min-content'),
       ]).updateMeta('utilities', name, pluginOrder[name], 2, true);
-    }
-    if (value === 'max-content') {
+    case 'max-content':
       return new Style(utility.class, [
         new Property(name, '-webkit-max-content'),
         new Property(name, '-moz-max-content'),
         new Property(name, 'max-content'),
       ]).updateMeta('utilities', name, pluginOrder[name], 3, true);
+    default:
+      return new Style(utility.class, new Property(name, sizes[utility.body])).updateMeta('utilities', name, pluginOrder[name], 1, true);
     }
-    return new Style(utility.class, new Property(name, value)).updateMeta('utilities', name, pluginOrder[name], 1, true);
   }
-  return utility.handler
+  return handler
     .handleSquareBrackets()
     .handleSpacing()
     .handleFraction()
@@ -386,33 +390,34 @@ function size(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/sizing.html#max-width
 // https://windicss.org/utilities/sizing.html#max-height
 function minMaxSize(utility: Utility, { theme }: PluginUtils): Output {
-  if (!utility.raw.match(/^(min|max)-[w|h]-/))
-    return;
-  const body = utility.raw.replace(/^(min|max)-[w|h]-/, '');
-  const prop = utility.raw.substring(0, 5).replace('h', 'height').replace('w', 'width');
+  const handler = utility.handler.catchPrefix(/^(min|max)-(w|h)/, true);
+  if (!handler || !handler.prefix) return;
+  const key = utility.raw.substring(handler.prefix.length + 1);
+  const prop = handler.prefix.replace('h', 'height').replace('w', 'width');
   const group = dashToCamel(prop) as ('minHeight'|'maxHeight'|'minWidth'|'maxWidth');
   const sizes = toType(theme(group), 'object') as { [key: string]: string };
   // handle static
-  if (Object.keys(sizes).includes(body)) {
-    const value = sizes[body];
-    if (value === 'min-content') {
+  if (key in sizes) {
+    const value = sizes[key];
+    switch (sizes[key]) {
+    case 'min-content':
       return new Style(utility.class, [
         new Property(prop, '-webkit-min-content'),
         new Property(prop, '-moz-min-content'),
         new Property(prop, 'min-content'),
       ]).updateMeta('utilities', group, pluginOrder[group], 2, true);
-    }
-    if (value === 'max-content') {
+    case 'max-content':
       return new Style(utility.class, [
         new Property(prop, '-webkit-max-content'),
         new Property(prop, '-moz-max-content'),
         new Property(prop, 'max-content'),
       ]).updateMeta('utilities', group, pluginOrder[group], 3, true);
+    default:
+      return new Style(utility.class, new Property(prop, value)).updateMeta('utilities', group, pluginOrder[group], 1, true);
     }
-    return new Style(utility.class, new Property(prop, value)).updateMeta('utilities', group, pluginOrder[group], 1, true);
   }
 
-  return utility.handler
+  return handler
     .handleSquareBrackets()
     .handleSpacing()
     .handleFraction()
@@ -430,71 +435,74 @@ function minMaxSize(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/typography.html#font-size
 function text(utility: Utility, { theme }: PluginUtils): Output {
   // handle font opacity
-  if (utility.raw.startsWith('text-opacity')) {
-    return utility.handler
-      .handleStatic(theme('textOpacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-text-opacity')
-      ?.updateMeta('utilities', 'textOpacity', pluginOrder.textOpacity, 1, true);
-  }
-  if (utility.raw.startsWith('text-shadow')) {
-    return (utility.raw === 'text-shadow'
+  const handler = utility.handler;
+  return handler.catchPrefix(/^text-opacity/, true)
+    ?.handleStatic(theme('textOpacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-text-opacity')
+    ?.updateMeta('utilities', 'textOpacity', pluginOrder.textOpacity, 1, true)
+
+    || handler.catchPrefix(/^text-shadow/, true)?.then(() => (utility.raw === 'text-shadow'
       ? new Property('text-shadow', theme('textShadow.DEFAULT', '0px 0px 1px rgb(0 0 0 / 20%), 0px 0px 1px rgb(1 0 5 / 10%)') as string)
       : utility.handler
         .handleStatic(theme('textShadow'))
         .createProperty('text-shadow')
-    )?.updateMeta('utilities', 'textShadow', pluginOrder.textShadow, 1, true);
-  }
-  if (utility.raw.startsWith('text-stroke')) {
-    if (utility.raw === 'text-stroke') return new Style('text-stroke', [
-      new Property('-webkit-text-stroke-color', theme('textStrokeColor.DEFAULT', '#e4e4e7') as string),
-      new Property('-webkit-text-stroke-width', theme('textStrokeWidth.DEFAULT', 'medium') as string),
-    ]).updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 1, true);
+    )?.updateMeta('utilities', 'textShadow', pluginOrder.textShadow, 1, true))
 
-    if (utility.raw.startsWith('text-stroke-opacity')) {
-      return utility.handler
-        .handleStatic(theme('opacity'))
-        .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-        .handleVariable()
-        .createProperty('--tw-ring-offset-opacity')
-        ?.updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 3, true);
-    }
-
-    return utility.clone('textStroke' + utility.raw.slice(11)).handler
-      .handleColor(theme('textStrokeColor'))
-      .handleOpacity(theme('opacity'))
+    || handler
+      .catchPrefix(/^text-stroke-opacity/, true)
+      ?.handleStatic(theme('opacity'))
+      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
       .handleVariable()
-      .createColorStyle(utility.class, '-webkit-text-stroke-color', '--tw-text-stroke-opacity')
-      ?.updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 2, true)
-  || utility.handler
-    .handleStatic(theme('textStrokeWidth'))
-    .handleNumber(0, undefined, 'int', (number) => `${number}px`)
-    .handleSize()
-    .createProperty('-webkit-text-stroke-width')
-    ?.updateMeta('utilities', 'textStrokeWidth', pluginOrder.textStrokeWidth, 1, true);
-  }
-  // handle text colors
-  const textColor = utility.handler
-    .handleColor(theme('textColor'))
-    .handleOpacity(theme('textOpacity'))
-    .handleSquareBrackets(notNumberLead)
-    .handleVariable()
-    .createColorStyle(utility.class, 'color', '--tw-text-opacity')
-    ?.updateMeta('utilities', 'textColor', pluginOrder.textColor, 0, true);
-  if (textColor) return textColor;
+      .createProperty('--tw-ring-offset-opacity')
+      ?.updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 3, true)
 
-  // handle font sizes
-  const amount = utility.amount;
-  const fontSizes = toType(theme('fontSize'), 'object') as { [key: string]: FontSize };
-  if (Object.keys(fontSizes).includes(amount)) return new Style(utility.class, generateFontSize(fontSizes[amount])).updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 1, true);
-  let value = utility.handler
-    .handleSquareBrackets(isNumberLead)
-    .handleNxl((number: number) => `${number}rem`)
-    .handleSize()
-    .value;
-  if (utility.raw.startsWith('text-size-$')) value = utility.handler.handleVariable().value;
-  if (value) return new Style(utility.class, [ new Property('font-size', value), new Property('line-height', '1') ]).updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 2, true);
+    || handler.catchPrefix(/^text-stroke/, true)?.then(() => {
+      if (utility.raw === 'text-stroke') return new Style('text-stroke', [
+        new Property('-webkit-text-stroke-color', theme('textStrokeColor.DEFAULT', '#e4e4e7') as string),
+        new Property('-webkit-text-stroke-width', theme('textStrokeWidth.DEFAULT', 'medium') as string),
+      ]).updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 1, true);
+
+      return utility.clone('textStroke' + utility.raw.slice(11)).handler
+        ?.handleColor(theme('textStrokeColor'))
+        .handleOpacity(theme('opacity'))
+        .handleVariable()
+        .createColorStyle(utility.class, '-webkit-text-stroke-color', '--tw-text-stroke-opacity')
+        ?.updateMeta('utilities', 'textStrokeColor', pluginOrder.textStrokeColor, 2, true)
+
+        || handler
+          ?.handleStatic(theme('textStrokeWidth'))
+          .handleNumber(0, undefined, 'int', (number) => `${number}px`)
+          .handleSize()
+          .createProperty('-webkit-text-stroke-width')
+          ?.updateMeta('utilities', 'textStrokeWidth', pluginOrder.textStrokeWidth, 1, true);
+    })
+
+    // handle text size variable
+    || handler.catchPrefix(/^text-size/, true)
+      ?.handleVariable()
+      .createStyle(utility.class, (value) => [ new Property('font-size', value), new Property('line-height', '1') ])
+      ?.updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 2, true)
+
+    // handle text color
+    || handler.catchPrefix(/^text/)
+      ?.handleColor(theme('textColor'))
+      .handleOpacity(theme('textOpacity'))
+      .handleSquareBrackets(notNumberLead)
+      .handleVariable()
+      .createColorStyle(utility.class, 'color', '--tw-text-opacity')
+      ?.updateMeta('utilities', 'textColor', pluginOrder.textColor, 0, true)
+
+    // handle font sizes
+    || handler.then(() => {
+      const fontSizes = toType(theme('fontSize'), 'object') as { [key: string]: FontSize };
+      if (utility.amount in fontSizes) return new Style(utility.class, generateFontSize(fontSizes[utility.amount])).updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 1, true);
+
+      return handler.handleSquareBrackets(isNumberLead).handleNxl((number: number) => `${number}rem`).handleSize()
+        .createStyle(utility.class, (value) => [ new Property('font-size', value), new Property('line-height', '1') ])
+        ?.updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 2, true);
+    });
 }
 
 // https://windicss.org/utilities/typography.html#font-family
@@ -505,24 +513,25 @@ function font(utility: Utility, { theme }: PluginUtils): Output {
   for (const [key, value] of Object.entries(fonts)) {
     map[key] = Array.isArray(value)? value.join(',') : value;
   }
-  return (
-    utility.handler
+  return utility.handler.catchPrefix(/^font/)?.then((handler) => (
+    handler
       .handleStatic(map)
       .createProperty('font-family')
       ?.updateMeta('utilities', 'fontFamily', pluginOrder.fontFamily, 1, true)
-    || utility.handler
+    || handler
       .handleStatic(theme('fontWeight'))
       .handleNumber(0, 900, 'int')
       .handleVariable()
       .createProperty('font-weight')
       ?.updateMeta('utilities', 'fontWeight', pluginOrder.fontWeight, 1, true)
-  );
+  ));
 }
 
 // https://windicss.org/utilities/typography.html#letter-spacing
 function letterSpacing(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('letterSpacing'))
+    .catchPrefix(/^-?tracking/)
+    ?.handleStatic(theme('letterSpacing'))
     .handleSquareBrackets()
     .handleSize()
     .handleNegative()
@@ -533,32 +542,29 @@ function letterSpacing(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/typography.html#text-decoration
 function textDecoration(utility: Utility, { theme }: PluginUtils): Output {
-  // handle text decoration opacity
-  if (utility.raw.startsWith('underline-opacity')) {
-    return utility.handler
-      .handleStatic(theme('textDecorationOpacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-line-opacity')
-      ?.updateMeta('utilities', 'textDecorationOpacity', pluginOrder.textDecorationOpacity, 1, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^underline-opacity/, true)
+    ?.handleStatic(theme('textDecorationOpacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-line-opacity')
+    ?.updateMeta('utilities', 'textDecorationOpacity', pluginOrder.textDecorationOpacity, 1, true)
 
-  if (utility.raw.startsWith('underline-offset')) {
-    return utility.handler
-      .handleStatic(theme('textDecorationOffset'))
-      .handleNumber(0, undefined, 'int', number => `${number}px`)
-      .handleSize()
-      .createProperty('text-underline-offset')
-      ?.updateMeta('utilities', 'textDecorationOffset', pluginOrder.textDecorationOffset, 1, true);
-  }
-  // handle text decoration color or length
-  return utility.handler
-    .handleColor(theme('textDecorationColor'))
+  || handler.catchPrefix(/^underline-offset/, true)
+    ?.handleStatic(theme('textDecorationOffset'))
+    .handleNumber(0, undefined, 'int', number => `${number}px`)
+    .handleSize()
+    .createProperty('text-underline-offset')
+    ?.updateMeta('utilities', 'textDecorationOffset', pluginOrder.textDecorationOffset, 1, true)
+
+  || handler.catchPrefix(/^underline/)
+    ?.handleColor(theme('textDecorationColor'))
     .handleOpacity(theme('opacity'))
     .handleVariable()
     .createColorStyle(utility.class, ['-webkit-text-decoration-color', 'text-decoration-color'], '--tw-line-opacity')
     ?.updateMeta('utilities', 'textDecorationColor', pluginOrder.textDecorationColor, 0, true)
-  || utility.handler
+
+  || handler
     .handleStatic(theme('textDecorationLength'))
     .handleNumber(0, undefined, 'int', (number: number) => `${number}px`)
     .handleSize()
@@ -569,7 +575,8 @@ function textDecoration(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/typography.html#line-height
 function lineHeight(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('lineHeight'))
+    .catchPrefix(/^leading/)
+    ?.handleStatic(theme('lineHeight'))
     .handleNumber(0, undefined, 'int', (number: number) => `${number * 0.25}rem`)
     .handleSquareBrackets()
     .handleSize()
@@ -589,39 +596,41 @@ function listStyleType(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/behaviors.html#placeholder-color
 // https://windicss.org/utilities/behaviors.html#placeholder-opacity
 function placeholder(utility: Utility, { theme, config }: PluginUtils): Output {
-  // handle placeholder opacity
-  if (utility.raw.startsWith('placeholder-opacity')) {
-    return utility.handler
-      .handleStatic(theme('placeholderOpacity'))
-      .handleSquareBrackets()
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .callback(value => generatePlaceholder(utility.class, new Property('--tw-placeholder-opacity', value), config('prefixer') as boolean)
-        .map(style => style.updateMeta('utilities', 'placeholderOpacity', pluginOrder.placeholderOpacity, 1, true)));
-  }
-  const color = utility.handler
-    .handleColor(theme('placeholderColor'))
+  const handler = utility.handler;
+  return handler.catchPrefix(/^placeholder-opacity/, true)
+    ?.handleStatic(theme('placeholderOpacity'))
+    .handleSquareBrackets()
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .callback(value => generatePlaceholder(utility.class, new Property('--tw-placeholder-opacity', value), config('prefixer') as boolean)
+      .map(style => style.updateMeta('utilities', 'placeholderOpacity', pluginOrder.placeholderOpacity, 1, true))
+    )
+
+  || handler.catchPrefix(/^placeholder/)
+    ?.handleColor(theme('placeholderColor'))
     .handleOpacity(theme('placeholderOpacity'))
     .handleSquareBrackets()
     .handleVariable()
-    .createColorStyle(utility.class, 'color', '--tw-placeholder-opacity');
-  if (color) return generatePlaceholder(color.selector || '', color.property, config('prefixer') as boolean).map(i => i.updateMeta('utilities', 'placeholderColor', pluginOrder.placeholderColor, 2, true));
+    .then((handler) => {
+      const color = handler.createColorStyle(utility.class, 'color', '--tw-placeholder-opacity');
+      if (color) return generatePlaceholder(color.selector || '', color.property, config('prefixer') as boolean).map(i => i.updateMeta('utilities', 'placeholderColor', pluginOrder.placeholderColor, 2, true));
+    });
 }
 
 // https://windicss.org/utilities/behaviors.html#caret-color
 // https://windicss.org/utilities/behaviors.html#caret-opacity
 function caret(utility: Utility, { theme }: PluginUtils): Output {
   // handle caret opacity
-  if (utility.raw.startsWith('caret-opacity')) {
-    return utility.handler
-      .handleStatic(theme('caretOpacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-caret-opacity')
-      ?.updateMeta('utilities', 'caretOpacity', pluginOrder.caretOpacity, 1, true);
-  }
-  return utility.handler
-    .handleColor(theme('caretColor'))
+  const handler = utility.handler;
+  return handler.catchPrefix(/^caret-opacity/, true)
+    ?.handleStatic(theme('caretOpacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-caret-opacity')
+    ?.updateMeta('utilities', 'caretOpacity', pluginOrder.caretOpacity, 1, true)
+
+  || handler.catchPrefix(/^caret/)
+    ?.handleColor(theme('caretColor'))
     .handleOpacity(theme('caretOpacity'))
     .handleVariable()
     .createColorStyle(utility.class, 'caret-color', '--tw-caret-opacity')
@@ -631,7 +640,8 @@ function caret(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/typography.html#tab-size
 function tabSize(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('tabSize'))
+    .catchPrefix(/^tab/)
+    ?.handleStatic(theme('tabSize'))
     .handleNumber(0, undefined, 'int')
     .handleSize()
     .createProperty(['-moz-tab-size', '-o-tab-size', 'tab-size'])
@@ -641,7 +651,8 @@ function tabSize(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/typography.html#text-indent
 function textIndent(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('textIndent'))
+    .catchPrefix(/^-?indent/)
+    ?.handleStatic(theme('textIndent'))
     .handleSize()
     .handleFraction()
     .handleNegative()
@@ -658,30 +669,30 @@ function background(utility: Utility, { theme }: PluginUtils): Output {
   const body = utility.body;
   // handle background positions
   const positions = toType(theme('backgroundPosition'), 'object') as { [key: string]: string };
-  if (Object.keys(positions).includes(body)) return new Property('background-position', positions[body]).updateMeta('utilities', 'backgroundPosition', pluginOrder.backgroundPosition, 1, true);
+  if (body in positions) return new Property('background-position', positions[body]).updateMeta('utilities', 'backgroundPosition', pluginOrder.backgroundPosition, 1, true);
   // handle background sizes
   const sizes = toType(theme('backgroundSize'), 'object') as { [key: string]: string };
-  if (Object.keys(sizes).includes(body)) return new Property('background-size', sizes[body]).updateMeta('utilities', 'backgroundSize', pluginOrder.backgroundSize, 1, true);
+  if (body in sizes) return new Property('background-size', sizes[body]).updateMeta('utilities', 'backgroundSize', pluginOrder.backgroundSize, 1, true);
   // handle background image
   const images = toType(theme('backgroundImage'), 'object') as { [key: string]: string };
-  if (Object.keys(images).includes(body)) {
+  if (body in images) {
     const prefixer = linearGradient(images[body]);
     if (Array.isArray(prefixer)) return new Style(utility.class, prefixer.map((i) => new Property('background-image', i))).updateMeta('utilities', 'backgroundImage', pluginOrder.backgroundImage, 2, true);
     return new Property('background-image', prefixer).updateMeta('utilities', 'backgroundImage', pluginOrder.backgroundImage, 1, true);
   }
   // handle background opacity
-  if (utility.raw.startsWith('bg-opacity'))
-    return utility.handler
-      .handleStatic(theme('backgroundOpacity'))
-      .handleSquareBrackets()
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-bg-opacity')
-      ?.updateMeta('utilities', 'backgroundOpacity', pluginOrder.backgroundOpacity, 1, true);
+  return utility.handler
+    .catchPrefix(/^bg-opacity/, true)
+    ?.handleStatic(theme('backgroundOpacity'))
+    .handleSquareBrackets()
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-bg-opacity')
+    ?.updateMeta('utilities', 'backgroundOpacity', pluginOrder.backgroundOpacity, 1, true)
 
   // handle background color
-  return utility.handler
-    .handleColor(theme('backgroundColor'))
+  || utility.handler.catchPrefix(/^bg/)
+    ?.handleColor(theme('backgroundColor'))
     .handleOpacity(theme('backgroundOpacity'))
     .handleSquareBrackets(notNumberLead)
     .handleVariable()
@@ -691,67 +702,85 @@ function background(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/backgrounds.html#gradient-from
 function gradientColorFrom(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('from-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-from-opacity')
-      ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 2, true);
-  }
-  const handler = utility.handler.handleColor(theme('gradientColorStops')).handleOpacity(theme('opacity')).handleVariable().handleSquareBrackets();
-  if (handler.color || handler.value) {
-    return new Style(utility.class, [
-      new Property('--tw-gradient-from', handler.createColorValue('var(--tw-from-opacity, 1)')),
-      new Property('--tw-gradient-stops', 'var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0))'),
-    ]).updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 1, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^from-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-from-opacity')
+    ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 2, true)
+
+  || handler.catchPrefix(/^from/)
+    ?.handleColor(theme('gradientColorStops'))
+    .handleOpacity(theme('opacity'))
+    .handleVariable()
+    .handleSquareBrackets()
+    .then(handler => {
+      if (handler.color || handler.value) {
+        return new Style(utility.class, [
+          new Property('--tw-gradient-from', handler.createColorValue('var(--tw-from-opacity, 1)')),
+          new Property('--tw-gradient-stops', 'var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0))'),
+        ]).updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 1, true);
+      }
+    });
 }
 
 // https://windicss.org/utilities/backgrounds.html#gradient-via
 function gradientColorVia(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('via-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-via-opacity')
-      ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 4, true);
-  }
-  const handler = utility.handler.handleColor(theme('gradientColorStops')).handleOpacity(theme('opacity')).handleVariable().handleSquareBrackets();
-  if (handler.color || handler.value) {
-    return new Style(utility.class,
-      new Property('--tw-gradient-stops', `var(--tw-gradient-from), ${handler.createColorValue('var(--tw-via-opacity, 1)')}, var(--tw-gradient-to, rgba(255, 255, 255, 0))`)
-    )?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 3, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^via-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-via-opacity')
+    ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 4, true)
+
+  || handler.catchPrefix(/^via/, true)
+    ?.handleColor(theme('gradientColorStops'))
+    .handleOpacity(theme('opacity'))
+    .handleVariable()
+    .handleSquareBrackets()
+    .then(handler => {
+      if (handler.color || handler.value) {
+        return new Style(utility.class,
+          new Property('--tw-gradient-stops', `var(--tw-gradient-from), ${handler.createColorValue('var(--tw-via-opacity, 1)')}, var(--tw-gradient-to, rgba(255, 255, 255, 0))`)
+        )?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 3, true);
+      }
+    });
 }
 
 // https://windicss.org/utilities/backgrounds.html#gradient-to
 function gradientColorTo(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('to-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-to-opacity')
-      ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 6, true);
-  }
-  const handler = utility.handler.handleColor(theme('gradientColorStops')).handleOpacity(theme('opacity')).handleVariable().handleSquareBrackets();
-  if (handler.color || handler.value) {
-    return new Style(utility.class,
-      new Property('--tw-gradient-to', handler.createColorValue('var(--tw-to-opacity, 1)'))
-    )?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 5, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^to-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-to-opacity')
+    ?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 6, true)
+
+  || handler.catchPrefix(/^to/, true)
+    ?.handleColor(theme('gradientColorStops'))
+    .handleOpacity(theme('opacity'))
+    .handleVariable()
+    .handleSquareBrackets()
+    .then(handler => {
+      if (handler.color || handler.value) {
+        return new Style(utility.class,
+          new Property('--tw-gradient-to', handler.createColorValue('var(--tw-to-opacity, 1)'))
+        )?.updateMeta('utilities', 'gradientColorStops', pluginOrder.gradientColorStops, 5, true);
+      }
+    });
 }
 
 // https://windicss.org/utilities/borders.html#border-radius
 function borderRadius(utility: Utility, { theme }: PluginUtils): Output {
-  const raw = [ 'rounded', 'rounded-t', 'rounded-l', 'rounded-r', 'rounded-b', 'rounded-tl', 'rounded-tr', 'rounded-br', 'rounded-bl' ].includes(utility.raw) ? utility.raw + '-DEFAULT' : utility.raw;
-  utility = utility.clone(raw);
+  let raw = utility.raw;
+  if (utility.match(/^rounded(-[trbl][trbl]?)?$/)) raw += '-DEFAULT';
   const directions = expandDirection(raw.match(/rounded-[trbl][trbl]?-/)?.[0].slice(8, -1) || '', true);
   if (!directions) return;
-  return utility.handler
-    .handleStatic(theme('borderRadius'))
+  return utility.handler.catchPrefix(/^rounded(-[trbl][trbl]?)?/)
+    ?.handleStatic(theme('borderRadius'))
     .handleSquareBrackets()
     .handleFraction()
     .handleNxl((number: number) => `${number * 0.5}rem`)
@@ -764,53 +793,44 @@ function borderRadius(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/borders.html#border-width
 // https://windicss.org/utilities/borders.html#border-color
 // https://windicss.org/utilities/borders.html#border-opacity
-function border(utility: Utility, { theme }: PluginUtils): Output {
+function border(utility: Utility, plugin: PluginUtils, dir = '*', real?: Utility): Output {
   // handle border opacity
-  if (utility.raw.startsWith('border-opacity')) {
-    return utility.handler
-      .handleStatic(theme('borderOpacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-border-opacity')
-      ?.updateMeta('utilities', 'borderOpacity', pluginOrder.borderOpacity, 1, true);
-  }
+  const handler = utility.handler;
+  const borders = toType(plugin.theme('borderWidth'), 'object') as { [key: string]: string };
+  return handler.catchPrefix(/^border-opacity/, true)
+    ?.handleStatic(plugin.theme('borderOpacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-border-opacity')
+    ?.updateMeta('utilities', 'borderOpacity', pluginOrder.borderOpacity, 1, true)
+
+  // handle border side
+  || dir === '*' && handler.catchPrefix(/^border-[tlbr]/, true)
+    ?.then(() => border(utility.clone('border' + utility.raw.slice(8)), plugin, expandDirection(handler.prefix?.slice(-1) as string, false)?.[0], utility))
 
   // handle border color
-  const borderColor = utility.handler
-    .handleColor(theme('borderColor'))
-    .handleOpacity(theme('borderOpacity'))
+  || handler.catchPrefix(/^border/)
+    ?.handleColor(plugin.theme('borderColor'))
+    .handleOpacity(plugin.theme('borderOpacity'))
     .handleSquareBrackets(notNumberLead)
     .handleVariable((variable: string) => utility.raw.startsWith('border-$') ? `var(--${variable})` : undefined)
-    .createColorStyle(utility.class, 'border-color', '--tw-border-opacity')
-    ?.updateMeta('utilities', 'borderColor', pluginOrder.borderColor, 2, true);
-  if (borderColor) return borderColor;
+    .then(() => {
+      if (dir !== '*' && handler.opacity)
+        return new Property(`border-${dir}-color`, handler.createColorValue(handler.opacity)).updateMeta('utilities', 'borderColor', pluginOrder.borderColor, 5, true);
+      return handler.createColorStyle((real || utility).class, dir === '*' ? 'border-color': `border-${dir}-color`, '--tw-border-opacity')
+        ?.updateMeta('utilities', 'borderColor', pluginOrder.borderColor, dir === '*' ? (handler.opacity ? 3 : 2) : 4, true);
+    })
+
 
   // handle border width
-  const directions = expandDirection(utility.raw.substring(7, 8), false) ?? [ '*' ];
-  const borders = toType(theme('borderWidth'), 'object') as { [key: string]: string };
-  const raw = [ 'border', 'border-t', 'border-r', 'border-b', 'border-l' ].includes(utility.raw) ? `${utility.raw}-${borders.DEFAULT ?? '1px'}` : utility.raw;
-
-  // handle border side color
-  const borderSide = utility.clone(raw.slice(7)).handler
-    .handleColor(theme('borderColor'))
-    .handleOpacity(theme('borderOpacity'));
-
-  if (borderSide.value || borderSide.color) {
-    if (borderSide.opacity) {
-      return new Property(`border-${directions[0]}-color`, borderSide.createColorValue(borderSide.opacity)).updateMeta('utilities', 'borderColor', pluginOrder.borderColor, 4, true);
-    }
-    return borderSide.createColorStyle(utility.class, `border-${directions[0]}-color`, '--tw-border-opacity')?.updateMeta('utilities', 'borderColor', pluginOrder.borderColor, 3, true);
-  }
-
-  utility = utility.clone(raw);
-  return utility.handler
-    .handleStatic(borders)
+  || handler.catchPrefix(/^border(-width)?/)
+    ?.handleStatic(borders)
     .handleSquareBrackets()
-    .handleNumber(0, undefined, 'int', (number: number) => /^border(-[tlbr])?$/.test(utility.key)? `${number}px`: undefined)
+    .handleNumber(0, undefined, 'int', (number: number) => `${number}px`)
     .handleSize()
     .handleVariable()
-    .createProperty(directions[0] === '*' ? 'border-width' : directions.map((i) => `border-${i}-width`))
-    ?.updateMeta('utilities', 'borderWidth', pluginOrder.borderWidth, (directions[0] === '*' ? 1 : (directions.length + 1)), true);
+    .createProperty(dir === '*' ? 'border-width': `border-${dir}-width`)
+    ?.updateMeta('utilities', 'borderWidth', pluginOrder.borderWidth, dir === '*' ? 1 : 2, true);
 }
 
 // https://windicss.org/utilities/borders.html#divide-width
@@ -819,68 +839,51 @@ function border(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/borders.html#divide-style
 function divide(utility: Utility, { theme }: PluginUtils): Output {
   // handle divide style
-  if (['solid', 'dashed', 'dotted', 'double', 'none'].includes(utility.amount)) return new Property('border-style', utility.amount).toStyle(utility.class).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideStyle', pluginOrder.divideStyle, 1, true);
+  const handler = utility.handler;
+  if (/^divide-(solid|dashed|dotted|double|none)$/.test(utility.raw)) return new Property('border-style', utility.amount).toStyle(utility.class).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideStyle', pluginOrder.divideStyle, 1, true);
+  if (utility.raw === 'divide-y-reverse')  return new Style(utility.class, new Property('--tw-divide-y-reverse', '1')).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 5, true);
+  if (utility.raw === 'divide-x-reverse')  return new Style(utility.class, new Property('--tw-divide-x-reverse', '1')).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 6, true);
+  if (handler._amount === 'x' || handler._amount === 'y') handler._amount = ''; // fix divide-x and divide-y
   // handle divide opacity
-  if (utility.raw.startsWith('divide-opacity'))
-    return utility.handler
-      .handleStatic(theme('divideOpacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-divide-opacity')
-      ?.toStyle(utility.class)
-      .child('> :not([hidden]) ~ :not([hidden])')
-      .updateMeta('utilities', 'divideOpacity', pluginOrder.divideOpacity, 1, true);
+  return handler.catchPrefix(/^divide-opacity/, true)
+    ?.handleStatic(theme('divideOpacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-divide-opacity')
+    ?.toStyle(utility.class)
+    .child('> :not([hidden]) ~ :not([hidden])')
+    .updateMeta('utilities', 'divideOpacity', pluginOrder.divideOpacity, 1, true)
+
   // handle divide color
-  const divideColor = utility.handler
-    .handleColor(theme('divideColor'))
+  || handler
+    .catchPrefix(/^divide/)
+    ?.handleColor(theme('divideColor'))
     .handleOpacity(theme('divideOpacity'))
     .handleVariable((variable: string) => utility.raw.startsWith('divide-$') ? `var(--${variable})` : undefined)
     .createColorStyle(utility.class, 'border-color', '--tw-divide-opacity')
     ?.child('> :not([hidden]) ~ :not([hidden])')
-    .updateMeta('utilities', 'divideColor', pluginOrder.divideColor, 0, true);
-  if (divideColor) return divideColor;
-  // handle divide width
-  switch (utility.raw) {
-  case 'divide-x-reverse':
-    return new Style(utility.class, new Property('--tw-divide-x-reverse', '1')).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 6, true);
-  case 'divide-y-reverse':
-    return new Style(utility.class, new Property('--tw-divide-y-reverse', '1')).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 5, true);
-  case 'divide-y':
-    return new Style(utility.class, [
-      new Property('--tw-divide-y-reverse', '0'),
-      new Property('border-top-width', 'calc(1px * calc(1 - var(--tw-divide-y-reverse)))'),
-      new Property('border-bottom-width', 'calc(1px * var(--tw-divide-y-reverse))'),
-    ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 3, true);
-  case 'divide-x':
-    return new Style(utility.class, [
-      new Property('--tw-divide-x-reverse', '0'),
-      new Property('border-right-width', 'calc(1px * var(--tw-divide-x-reverse))'),
-      new Property('border-left-width', 'calc(1px * calc(1 - var(--tw-divide-x-reverse)))'),
-    ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 4, true);
-  }
-  return utility.handler
+    .updateMeta('utilities', 'divideColor', pluginOrder.divideColor, 0, true)
+  // handle divide width dynamic
+  || handler.catchPrefix(/^divide-[xy]/, true)
+    ?.handleStatic(theme('divideWidth'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'float', (number: number) => `${number}px`)
     .handleSize()
     .handleVariable()
     .callback(value => {
-      const centerMatch = utility.raw.match(/^-?divide-[x|y]/);
-      if (centerMatch) {
-        const center = centerMatch[0].replace(/^-?divide-/, '');
-        switch (center) {
-        case 'x':
-          return new Style(utility.class, [
-            new Property('--tw-divide-x-reverse', '0'),
-            new Property('border-right-width', `calc(${value} * var(--tw-divide-x-reverse))`),
-            new Property('border-left-width', `calc(${value} * calc(1 - var(--tw-divide-x-reverse)))`),
-          ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 2, true);
-        case 'y':
-          return new Style(utility.class, [
-            new Property('--tw-divide-y-reverse', '0'),
-            new Property('border-top-width', `calc(${value} * calc(1 - var(--tw-divide-y-reverse)))`),
-            new Property('border-bottom-width', `calc(${value} * var(--tw-divide-y-reverse))`),
-          ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 1, true);
-        }
+      switch (handler.prefix?.slice(-1)) {
+      case 'x':
+        return new Style(utility.class, [
+          new Property('--tw-divide-x-reverse', '0'),
+          new Property('border-right-width', `calc(${value} * var(--tw-divide-x-reverse))`),
+          new Property('border-left-width', `calc(${value} * calc(1 - var(--tw-divide-x-reverse)))`),
+        ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 2, true);
+      case 'y':
+        return new Style(utility.class, [
+          new Property('--tw-divide-y-reverse', '0'),
+          new Property('border-top-width', `calc(${value} * calc(1 - var(--tw-divide-y-reverse)))`),
+          new Property('border-bottom-width', `calc(${value} * var(--tw-divide-y-reverse))`),
+        ]).child('> :not([hidden]) ~ :not([hidden])').updateMeta('utilities', 'divideWidth', pluginOrder.divideWidth, 1, true);
       }
     });
 }
@@ -888,31 +891,31 @@ function divide(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/borders.html#ring-offset-width
 // https://windicss.org/utilities/borders.html#ring-offset-color
 function ringOffset(utility: Utility, { theme }: PluginUtils): Output {
-  let value;
   // handle ring offset width variable
-  if (utility.raw.startsWith('ringOffset-width-$')) {
-    value = utility.handler.handleVariable().value;
-    if (value) return new Property('--tw-ring-offset-width', value).toStyle(utility.class.replace('ringOffset', 'ring-offset')).updateMeta('utilities', 'ringOffsetWidth', pluginOrder.ringOffsetWidth, 2, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^ringOffset-width/, true)
+    ?.handleVariable()
+    .createStyle(utility.class.replace('ringOffset', 'ring-offset'), value => new Property('--tw-ring-offset-width', value))
+    ?.updateMeta('utilities', 'ringOffsetWidth', pluginOrder.ringOffsetWidth, 2, true)
 
-  if (utility.raw.startsWith('ringOffset-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-ring-offset-opacity')
-      ?.updateMeta('utilities', 'ringOffsetColor', pluginOrder.ringOffsetColor, 2, true);
-  }
+  || handler.catchPrefix(/^ringOffset-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-ring-offset-opacity')
+    ?.updateMeta('utilities', 'ringOffsetColor', pluginOrder.ringOffsetColor, 2, true)
 
-  // handle ring offset color || ring offset width
-  return utility.handler
-    .handleColor(theme('ringOffsetColor'))
+  // handle ring offset color
+  || handler.catchPrefix(/^ringOffset/)
+    ?.handleColor(theme('ringOffsetColor'))
     .handleOpacity('ringOpacity')
     .handleVariable()
     .handleSquareBrackets()
     .createColorStyle(utility.class.replace('ringOffset', 'ring-offset'), '--tw-ring-offset-color', '--tw-ring-offset-opacity')
     ?.updateMeta('utilities', 'ringOffsetColor', pluginOrder.ringOffsetColor, 1, true)
-  || utility.handler
+
+  // handle ring offset width
+  || handler
     .handleStatic(theme('ringOffsetWidth'))
     .handleSquareBrackets(isNumberLead)
     .handleNumber(0, undefined, 'float', (number: number) => `${number}px`)
@@ -925,51 +928,51 @@ function ringOffset(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/borders.html#ring-color
 // https://windicss.org/utilities/borders.html#ring-opacity
 function ring(utility: Utility, utils: PluginUtils): Output {
+  if (utility.raw === 'ring-inset') return new Property('--tw-ring-inset', 'inset').updateMeta('utilities', 'ringWidth', pluginOrder.ringWidth, 3, true);
+
   // handle ring offset
-  if (utility.raw.startsWith('ring-offset')) return ringOffset(utility.clone(utility.raw.replace('ring-offset', 'ringOffset')), utils);
+  const handler = utility.handler;
+  return handler.catchPrefix(/^ring-offset/, true)
+    ?.then(() => ringOffset(utility.clone(utility.raw.replace('ring-offset', 'ringOffset')), utils))
+
   // handle ring opacity
-  if (utility.raw.startsWith('ring-opacity'))
-    return utility.handler
-      .handleStatic(utils.theme('ringOpacity'))
-      .handleSquareBrackets()
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-ring-opacity')
-      ?.updateMeta('utilities', 'ringOpacity', pluginOrder.ringOpacity, 1, true);
+  || handler.catchPrefix(/^ring-opacity/, true)
+    ?.handleStatic(utils.theme('ringOpacity'))
+    .handleSquareBrackets()
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-ring-opacity')
+    ?.updateMeta('utilities', 'ringOpacity', pluginOrder.ringOpacity, 1, true)
+
   // handle ring color
-  const ringColor = utility.handler
-    .handleColor(utils.theme('ringColor'))
+  || handler.catchPrefix(/^ring/)
+    ?.handleColor(utils.theme('ringColor'))
     .handleOpacity(utils.theme('ringOpacity'))
     .handleSquareBrackets(notNumberLead)
     .handleVariable((variable: string) => utility.raw.startsWith('ring-$') ? `var(--${variable})` : undefined)
     .createColorStyle(utility.class, '--tw-ring-color', '--tw-ring-opacity')
-    ?.updateMeta('utilities', 'ringColor', pluginOrder.ringColor, 0, true);
+    ?.updateMeta('utilities', 'ringColor', pluginOrder.ringColor, 0, true)
 
-  if (ringColor) return ringColor;
   // handle ring width
-  if (utility.raw === 'ring-inset') return new Property('--tw-ring-inset', 'inset').updateMeta('utilities', 'ringWidth', pluginOrder.ringWidth, 3, true);
-  const value = utility.raw === 'ring'
-    ? (toType(utils.theme('ringWidth.DEFAULT'), 'string') ?? '3px')
-    : utility.handler
-      .handleStatic(utils.theme('ringWidth'))
-      .handleSquareBrackets()
-      .handleNumber(0, undefined, 'float', (number: number) => `${number}px`)
-      .handleSize()
-      .handleVariable()
-      .value;
-  if (!value) return;
-  return new Style(utility.class, [
-    new Property('--tw-ring-offset-shadow', 'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)'),
-    new Property('--tw-ring-shadow', `var(--tw-ring-inset) 0 0 0 calc(${value} + var(--tw-ring-offset-width)) var(--tw-ring-color)`),
-    new Property(['-webkit-box-shadow', 'box-shadow'], 'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)'),
-  ]).updateMeta('utilities', 'ringWidth', pluginOrder.ringWidth, (utility.raw === 'ring' ? 1 : 2), true);
+  || handler.catchPrefix(/^ring(-width)?/)
+    ?.handleStatic(utils.theme('ringWidth'))
+    .handleSquareBrackets()
+    .handleNumber(0, undefined, 'float', (number: number) => `${number}px`)
+    .handleSize()
+    .handleVariable()
+    .createStyle(utility.class, value => [
+      new Property('--tw-ring-offset-shadow', 'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)'),
+      new Property('--tw-ring-shadow', `var(--tw-ring-inset) 0 0 0 calc(${value} + var(--tw-ring-offset-width)) var(--tw-ring-color)`),
+      new Property(['-webkit-box-shadow', 'box-shadow'], 'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)'),
+    ])
+    ?.updateMeta('utilities', 'ringWidth', pluginOrder.ringWidth, (utility.raw === 'ring' ? 1 : 2), true);
 }
 
 // https://windicss.org/utilities/filters.html#filter-blur
 function blur(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw === 'blur') utility.raw = 'blur-DEFAULT';
   return utility.handler
-    .handleBody(theme('blur'))
+    .catchPrefix(/^blur/)
+    ?.handleBody(theme('blur'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'int', (number) => `${number}px`)
     .handleSize()
@@ -980,7 +983,8 @@ function blur(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/filters.html#filter-brightness
 function brightness(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleBody(theme('brightness'))
+    .catchPrefix(/^brightness/)
+    ?.handleBody(theme('brightness'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
     .createProperty('--tw-brightness', value => `brightness(${value})`)
@@ -990,7 +994,8 @@ function brightness(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/filters.html#filter-contrast
 function contrast(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleBody(theme('contrast'))
+    .catchPrefix(/^contrast/)
+    ?.handleBody(theme('contrast'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
     .createProperty('--tw-contrast', value => `contrast(${value})`)
@@ -1005,16 +1010,16 @@ function dropShadow(utility: Utility, { theme }: PluginUtils): Output {
   } else {
     const dropShadows = theme('dropShadow') as {[key:string]:string|string[]};
     const amount = utility.amount;
-    if (utility.raw.startsWith('drop-shadow') && amount in dropShadows) value = dropShadows[amount];
+    if (utility.handler.isStatic(dropShadows, amount)) value = dropShadows[amount];
   }
   if (value) return new Property('--tw-drop-shadow', Array.isArray(value)? value.map(i => `drop-shadow(${i})`).join(' '): `drop-shadow(${value})`).updateMeta('utilities', 'dropShadow', pluginOrder.dropShadow, 1, true);
 }
 
 // https://windicss.org/utilities/filters.html#filter-grayscale
 function grayscale(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw === 'grayscale') utility.raw = 'grayscale-DEFAULT';
   return utility.handler
-    .handleBody(theme('grayscale'))
+    .catchPrefix(/^grayscale/)
+    ?.handleBody(theme('grayscale'))
     .handleSquareBrackets()
     .handleNumber(0, 100, 'int', (number) => `${number/100}`)
     .createProperty('--tw-grayscale', value => `grayscale(${value})`)
@@ -1024,7 +1029,8 @@ function grayscale(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/filters.html#filter-hue-rotate
 function hueRotate(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleBody(theme('hueRotate'))
+    .catchPrefix(/^-?hue-rotate/)
+    ?.handleBody(theme('hueRotate'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'float', (number) => `${number}deg`)
     .handleNegative()
@@ -1034,9 +1040,9 @@ function hueRotate(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/filters.html#filter-invert
 function invert(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw === 'invert') utility.raw = 'invert-DEFAULT';
   return utility.handler
-    .handleBody(theme('invert'))
+    .catchPrefix(/^invert/)
+    ?.handleBody(theme('invert'))
     .handleSquareBrackets()
     .handleNumber(0, 100, 'int', (number) => `${number/100}`)
     .createProperty('--tw-invert', value => `invert(${value})`)
@@ -1046,7 +1052,8 @@ function invert(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/filters.html#filter-saturate
 function saturate(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleBody(theme('saturate'))
+    .catchPrefix(/^saturate/)
+    ?.handleBody(theme('saturate'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
     .createProperty('--tw-saturate', value => `saturate(${value})`)
@@ -1055,9 +1062,9 @@ function saturate(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/filters.html#filter-sepia
 function sepia(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw === 'sepia') utility.raw = 'sepia-DEFAULT';
   return utility.handler
-    .handleBody(theme('sepia'))
+    .catchPrefix(/^sepia/)
+    ?.handleBody(theme('sepia'))
     .handleSquareBrackets()
     .handleNumber(0, 100, 'int', (number) => `${number/100}`)
     .createProperty('--tw-sepia', value => `sepia(${value})`)
@@ -1078,9 +1085,9 @@ function backdrop(utility: Utility, { theme }: PluginUtils): Output {
   utility = utility.clone(utility.raw.slice(9));
   switch (utility.match(/[^-]+/)) {
   case 'blur':
-    if (utility.raw === 'blur') utility.raw = 'blur-DEFAULT';
     return utility.handler
-      .handleBody(theme('backdropBlur'))
+      .catchPrefix(/^blur/)
+      ?.handleBody(theme('backdropBlur'))
       .handleSquareBrackets()
       .handleNumber(0, undefined, 'int', (number) => `${number}px`)
       .handleSize()
@@ -1088,60 +1095,65 @@ function backdrop(utility: Utility, { theme }: PluginUtils): Output {
       ?.updateMeta('utilities', 'backdropBlur', pluginOrder.backdropBlur, 1, true);
   case 'brightness':
     return utility.handler
-      .handleBody(theme('backdropBrightness'))
+      .catchPrefix(/^brightness/)
+      ?.handleBody(theme('backdropBrightness'))
       .handleSquareBrackets()
       .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-brightness', value => `brightness(${value})`)
       ?.updateMeta('utilities', 'backdropBrightness', pluginOrder.backdropBrightness, 1, true);
   case 'contrast':
     return utility.handler
-      .handleBody(theme('backdropContrast'))
+      .catchPrefix(/^contrast/)
+      ?.handleBody(theme('backdropContrast'))
       .handleSquareBrackets()
       .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-contrast', value => `contrast(${value})`)
       ?.updateMeta('utilities', 'backdropContrast', pluginOrder.backdropContrast, 1, true);
   case 'grayscale':
-    if (utility.raw === 'grayscale') utility.raw = 'grayscale-DEFAULT';
     return utility.handler
-      .handleBody(theme('backdropGrayscale'))
+      .catchPrefix(/^grayscale/)
+      ?.handleBody(theme('backdropGrayscale'))
       .handleSquareBrackets()
       .handleNumber(0, 100, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-grayscale', value => `grayscale(${value})`)
       ?.updateMeta('utilities', 'backdropGrayscale', pluginOrder.backdropGrayscale, 1, true);
   case 'hue':
     return utility.handler
-      .handleBody(theme('backdropHueRotate'))
+      .catchPrefix(/^-?hue-rotate/)
+      ?.handleBody(theme('backdropHueRotate'))
       .handleSquareBrackets()
       .handleNumber(0, undefined, 'float', (number) => `${number}deg`)
       .handleNegative()
       .createProperty('--tw-backdrop-hue-rotate', value => `hue-rotate(${value})`)
       ?.updateMeta('utilities', 'backdropHueRotate', pluginOrder.backdropHueRotate, 1, true);
   case 'invert':
-    if (utility.raw === 'invert') utility.raw = 'invert-DEFAULT';
     return utility.handler
-      .handleBody(theme('backdropInvert'))
+      .catchPrefix(/^invert/)
+      ?.handleBody(theme('backdropInvert'))
       .handleSquareBrackets()
       .handleNumber(0, 100, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-invert', value => `invert(${value})`)
       ?.updateMeta('utilities', 'backdropInvert', pluginOrder.backdropInvert, 1, true);
   case 'opacity':
     return utility.handler
-      .handleBody(theme('backdropOpacity'))
+      .catchPrefix(/^opacity/)
+      ?.handleBody(theme('backdropOpacity'))
       .handleSquareBrackets()
       .handleNumber(0, 100, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-opacity', value => `opacity(${value})`)
       ?.updateMeta('utilities', 'backdropOpacity', pluginOrder.backdropOpacity, 1, true);
   case 'saturate':
     return utility.handler
-      .handleBody(theme('backdropSaturate'))
+      .catchPrefix(/^saturate/)
+      ?.handleBody(theme('backdropSaturate'))
       .handleSquareBrackets()
       .handleNumber(0, undefined, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-saturate', value => `saturate(${value})`)
       ?.updateMeta('utilities', 'backdropSaturate', pluginOrder.backdropSaturate, 1, true);
   case 'sepia':
-    if (utility.raw === 'sepia') utility.raw = 'sepia-DEFAULT';
     return utility.handler
-      .handleBody(theme('backdropSepia'))
+      .catchPrefix(/^sepia/)
+      ?.handleBody(theme('backdropSepia'))
       .handleSquareBrackets()
       .handleNumber(0, 100, 'int', (number) => `${number/100}`)
       .createProperty('--tw-backdrop-sepia', value => `sepia(${value})`)
@@ -1151,18 +1163,16 @@ function backdrop(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/effects.html#box-shadow
 function boxShadow(utility: Utility, { theme }: PluginUtils): Output {
-  const body = utility.body || 'DEFAULT';
-  const shadows = toType(theme('boxShadow'), 'object') as { [key: string]: string };
-  if (Object.keys(shadows).includes(body)) {
-    const shadow = shadows[body].replace(/rgba\s*\(\s*0\s*,\s*0\s*,\s*0/g, 'rgba(var(--tw-shadow-color)');
-    return new Style(utility.class, [
-      new Property('--tw-shadow-color', '0, 0, 0'),
-      new Property('--tw-shadow', shadow),
-      new Property(['-webkit-box-shadow', 'box-shadow'], 'var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)'),
-    ]).updateMeta('utilities', 'boxShadow', pluginOrder.boxShadow, 0, true);
-  }
-  // handle shadowColor
   return utility.handler
+    .catchPrefix(/^box-shadow/)
+    ?.handleBody(theme('boxShadow'))
+    .createStyle(utility.class, value => [
+      new Property('--tw-shadow-color', '0, 0, 0'),
+      new Property('--tw-shadow', value.replace(/rgba\s*\(\s*0\s*,\s*0\s*,\s*0/g, 'rgba(var(--tw-shadow-color)')),
+      new Property(['-webkit-box-shadow', 'box-shadow'], 'var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)'),
+    ])?.updateMeta('utilities', 'boxShadow', pluginOrder.boxShadow, 0, true)
+
+  || utility.handler
     .handleColor(theme('boxShadowColor'))
     .handleOpacity(theme('opacity'))
     .handleSquareBrackets()
@@ -1174,7 +1184,8 @@ function boxShadow(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/effects.html#opacity
 function opacity(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('opacity'))
+    .catchPrefix(/^opacity/)
+    ?.handleStatic(theme('opacity'))
     .handleSquareBrackets()
     .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
     .handleVariable()
@@ -1203,7 +1214,8 @@ function transition(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/transitions.html#transition-duration
 function duration(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('transitionDuration'))
+    .catchPrefix(/^duration/)
+    ?.handleStatic(theme('transitionDuration'))
     .handleSquareBrackets()
     .handleTime(0, undefined, 'float')
     .handleNumber(0, undefined, 'int', (number: number) => `${number}ms`)
@@ -1223,7 +1235,8 @@ function transitionTimingFunction(utility: Utility, { theme }: PluginUtils): Out
 // https://windicss.org/utilities/transitions.html#transition-delay
 function delay(utility: Utility, { theme }: PluginUtils): Output {
   return utility.handler
-    .handleStatic(theme('transitionDelay'))
+    .catchPrefix(/^delay/)
+    ?.handleStatic(theme('transitionDelay'))
     .handleSquareBrackets()
     .handleTime(0, undefined, 'float')
     .handleNumber(0, undefined, 'int', (number: number) => `${number}ms`)
@@ -1234,17 +1247,18 @@ function delay(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/behaviors.html#animation
 function animation(utility: Utility, { theme, config }: PluginUtils): Output {
-  const body = utility.body;
   if (utility.raw.startsWith('animate-ease')) {
     return utility.clone(utility.raw.slice(8)).handler
-      .handleBody(theme('animationTimingFunction'))
+      .catchPrefix(/^ease/)
+      ?.handleBody(theme('animationTimingFunction'))
       .handleSquareBrackets()
       .createProperty(['-webkit-animation-timing-function', 'animation-timing-function'])
       ?.updateMeta('utilities', 'animation', pluginOrder.animation, 20, true);
   }
   if (utility.raw.startsWith('animate-duration')) {
     return utility.clone(utility.raw.slice(8)).handler
-      .handleStatic(theme('animationDuration'))
+      .catchPrefix(/^duration/)
+      ?.handleStatic(theme('animationDuration'))
       .handleSquareBrackets()
       .handleTime(0, undefined, 'float')
       .handleNumber(0, undefined, 'int', (number: number) => `${number}ms`)
@@ -1254,7 +1268,8 @@ function animation(utility: Utility, { theme, config }: PluginUtils): Output {
   }
   if (utility.raw.startsWith('animate-delay')) {
     return utility.clone(utility.raw.slice(8)).handler
-      .handleStatic(theme('animationDelay'))
+      .catchPrefix(/^delay/)
+      ?.handleStatic(theme('animationDelay'))
       .handleSquareBrackets()
       .handleTime(0, undefined, 'float')
       .handleNumber(0, undefined, 'int', (number: number) => `${number}ms`)
@@ -1262,10 +1277,11 @@ function animation(utility: Utility, { theme, config }: PluginUtils): Output {
       .createProperty(['-webkit-animation-delay', 'animation-delay'])
       ?.updateMeta('utilities', 'animation', pluginOrder.animation, 22, true);
   }
-  const animateIterationCount = utility.handler.handleBody(theme('animationIterationCount')).handleNumber(0, undefined, 'int').handleSquareBrackets().value;
+  const animateIterationCount = utility.handler.catchPrefix(/^animate/, true)?.handleBody(theme('animationIterationCount')).value || utility.handler.catchPrefix(/^animate-repeat/)?.handleNumber(0, undefined, 'int').handleSquareBrackets().value;
   if (animateIterationCount) return new Property(['-webkit-animation-iteration-count', 'animation-iteration-count'], animateIterationCount).updateMeta('utilities', 'animation', pluginOrder.animation, 23, true);
   const animations = toType(theme('animation'), 'object') as { [key: string]: string | { [key: string]: string } };
-  if (Object.keys(animations).includes(body)) {
+  const body = utility.body;
+  if (body in animations) {
     let value = animations[body];
     const prop = config('prefixer') ? ['-webkit-animation', 'animation'] : 'animation';
     if (value === 'none') return new Property(prop, 'none').updateMeta('utilities', 'animation', pluginOrder.animation, 1, true);
@@ -1309,151 +1325,156 @@ function animation(utility: Utility, { theme, config }: PluginUtils): Output {
 function transformOrigin(utility: Utility, { theme }: PluginUtils): Output {
   const body = utility.body;
   const origins = toType(theme('transformOrigin'), 'object') as { [key: string]: string };
-  if (Object.keys(origins).includes(body)) return new Property(['-webkit-transform-origin', '-ms-transform-origin', 'transform-origin'], origins[body]).updateMeta('utilities', 'transformOrigin', pluginOrder.transformOrigin, 0, true);
+  if (body in origins) return new Property(['-webkit-transform-origin', '-ms-transform-origin', 'transform-origin'], origins[body]).updateMeta('utilities', 'transformOrigin', pluginOrder.transformOrigin, 0, true);
 }
 
 // https://windicss.org/utilities/transforms.html#transform-scale
 function scale(utility: Utility, { theme }: PluginUtils): Output {
-  return utility.handler
-    .handleStatic(theme('scale'))
+  const handler = utility.handler;
+  return handler.catchPrefix(/^scale(-[xyz])?/, true)
+    ?.handleStatic(theme('scale'))
     .handleNumber(0, undefined, 'int', (number: number) => (number / 100).toString())
     .handleVariable()
     .callback(value => {
-      if (utility.raw.startsWith('scale-x')) return new Property('--tw-scale-x', value).updateMeta('utilities', 'scale', pluginOrder.scale, 2, true);
-      if (utility.raw.startsWith('scale-y')) return new Property('--tw-scale-y', value).updateMeta('utilities', 'scale', pluginOrder.scale, 3, true);
-      if (utility.raw.startsWith('scale-z')) return new Property('--tw-scale-z', value).updateMeta('utilities', 'scale', pluginOrder.scale, 4, true);
-      return new Property(['--tw-scale-x', '--tw-scale-y', '--tw-scale-z'], value).updateMeta('utilities', 'scale', pluginOrder.scale, 1, true);
+      switch (handler.prefix?.slice(-1)) {
+      case 'x': return new Property('--tw-scale-x', value).updateMeta('utilities', 'scale', pluginOrder.scale, 2, true);
+      case 'y': return new Property('--tw-scale-y', value).updateMeta('utilities', 'scale', pluginOrder.scale, 3, true);
+      case 'z': return new Property('--tw-scale-z', value).updateMeta('utilities', 'scale', pluginOrder.scale, 4, true);
+      default: return new Property(['--tw-scale-x', '--tw-scale-y', '--tw-scale-z'], value).updateMeta('utilities', 'scale', pluginOrder.scale, 1, true);
+      }
     });
 }
 
 // https://windicss.org/utilities/transforms.html#transform-rotate
 function rotate(utility: Utility, { theme }: PluginUtils): Output {
-  return utility.handler
-    .handleStatic(theme('rotate'))
+  const handler = utility.handler;
+  return handler.catchPrefix(/^-?rotate(-[xyz])?/, true)
+    ?.handleStatic(theme('rotate'))
     .handleSquareBrackets()
     .handleNumber(0, undefined, 'float', (number: number) => `${number}deg`)
     .handleNegative()
     .handleVariable()
     .callback(value => {
-      const abs = utility.absolute;
-      if (abs.startsWith('rotate-x')) return new Property('--tw-rotate-x', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 2, true);
-      if (abs.startsWith('rotate-y')) return new Property('--tw-rotate-y', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 3, true);
-      if (abs.startsWith('rotate-z')) return new Property('--tw-rotate-z', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 4, true);
-      return new Property('--tw-rotate', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 1, true);
+      switch (handler.prefix?.slice(-1)) {
+      case 'x': return new Property('--tw-rotate-x', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 2, true);
+      case 'y': return new Property('--tw-rotate-y', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 3, true);
+      case 'z': return new Property('--tw-rotate-z', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 4, true);
+      default: return new Property('--tw-rotate', value).updateMeta('utilities', 'rotate', pluginOrder.rotate, 1, true);
+      }
     });
 }
 
 // https://windicss.org/utilities/transforms.html#transform-translate
 function translate(utility: Utility, { theme }: PluginUtils): Output {
-  const centerMatch = utility.raw.match(/^-?translate-[x|y|z]/);
-  if (centerMatch) {
-    const center = centerMatch[0].replace(/^-?translate-/, '');
-    return utility.handler
-      .handleStatic(theme('translate'))
-      .handleSquareBrackets()
-      .handleSpacing()
-      .handleFraction()
-      .handleSize()
-      .handleNegative()
-      .handleVariable()
-      .createProperty(`--tw-translate-${center}`)
-      ?.updateMeta('utilities', 'translate', pluginOrder.translate, utility.raw.charAt(0) === '-' ? 2 : 1, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^-?translate-[xyz]/, true)
+    ?.handleStatic(theme('translate'))
+    .handleSquareBrackets()
+    .handleSpacing()
+    .handleFraction()
+    .handleSize()
+    .handleNegative()
+    .handleVariable()
+    .createProperty(`--tw-translate-${handler.prefix?.slice(-1)}`)
+    ?.updateMeta('utilities', 'translate', pluginOrder.translate, utility.raw.charAt(0) === '-' ? 2 : 1, true);
 }
 
 // https://windicss.org/utilities/transforms.html#transform-skew
 function skew(utility: Utility, { theme }: PluginUtils): Output {
-  const centerMatch = utility.raw.match(/^-?skew-[x|y]/);
-  if (centerMatch) {
-    const center = centerMatch[0].replace(/^-?skew-/, '');
-    return utility.handler
-      .handleStatic(theme('skew'))
-      .handleSquareBrackets()
-      .handleNumber(0, undefined, 'float', (number: number) => `${number}deg`)
-      .handleNegative()
-      .handleVariable()
-      .createProperty(`--tw-skew-${center}`)
-      ?.updateMeta('utilities', 'skew', pluginOrder.skew, utility.raw.charAt(0) === '-' ? 2 : 1, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^-?skew-[xy]/, true)
+    ?.handleStatic(theme('skew'))
+    .handleSquareBrackets()
+    .handleNumber(0, undefined, 'float', (number: number) => `${number}deg`)
+    .handleNegative()
+    .handleVariable()
+    .createProperty(`--tw-skew-${handler.prefix?.slice(-1)}`)
+    ?.updateMeta('utilities', 'skew', pluginOrder.skew, utility.raw.charAt(0) === '-' ? 2 : 1, true);
 }
 
 // https://windicss.org/utilities/transforms.html#perspective
 function perspective(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('perspect-origin')) {
-    const origin = utility.clone('perspectOrigin' + utility.raw.slice(15)).handler
-      .handleBody(theme('perspectiveOrigin'))
+  return utility.handler.catchPrefix(/^perspect-origin/, true)
+    ?.then(() => {
+      const origin = utility.clone('perspectOrigin' + utility.raw.slice(15)).handler
+        .handleBody(theme('perspectiveOrigin'))
+        .handleSquareBrackets()
+        .createProperty(['-webkit-perspective-origin', 'perspective-origin'])
+        ?.updateMeta('utilities', 'perspectiveOrigin', pluginOrder.perspectiveOrigin, 0, true);
+      if (origin) return origin;
+    })
+    || utility.handler.catchPrefix(/^perspect/)
+      ?.handleStatic(theme('perspective'))
+      .handleNumber(0, undefined, 'int', number => `${number}px`)
+      .handleSize()
       .handleSquareBrackets()
-      .createProperty(['-webkit-perspective-origin', 'perspective-origin'])
-      ?.updateMeta('utilities', 'perspectiveOrigin', pluginOrder.perspectiveOrigin, 0, true);
-    if (origin) return origin;
-  }
-  return utility.handler
-    .handleStatic(theme('perspective'))
-    .handleNumber(0, undefined, 'int', number => `${number}px`)
-    .handleSize()
-    .handleSquareBrackets()
-    .createProperty(['-webkit-perspective', 'perspective'])
-    ?.updateMeta('utilities', 'perspective', pluginOrder.perspective, 0, true);
+      .createProperty(['-webkit-perspective', 'perspective'])
+      ?.updateMeta('utilities', 'perspective', pluginOrder.perspective, 0, true);
 }
 
 // https://windicss.org/utilities/behaviors.html#cursor
 function cursor(utility: Utility, { theme }: PluginUtils): Output {
   const body = utility.body;
   const cursors = toType(theme('cursor'), 'object') as { [key: string]: string };
-  if (Object.keys(cursors).includes(body)) return new Property('cursor', cursors[body]).updateMeta('utilities', 'cursor', pluginOrder.cursor, 1, true);
+  if (body in cursors) return new Property('cursor', cursors[body]).updateMeta('utilities', 'cursor', pluginOrder.cursor, 1, true);
 }
 
 // https://windicss.org/utilities/behaviors.html#outline
 function outline(utility: Utility, { theme }: PluginUtils): Output {
   const amount = utility.amount;
+  const handler = utility.handler;
   const staticMap = toType(theme('outline'), 'object') as { [key: string]: [outline: string, outlineOffset: string] };
-  if (Object.keys(staticMap).includes(amount))
+  if (amount in staticMap)
     return new Style(utility.class, [ new Property('outline', staticMap[amount][0]), new Property('outline-offset', staticMap[amount][1]) ]).updateMeta('utilities', 'outline', pluginOrder.outline, 1, true);
 
-  if (utility.raw.startsWith('outline-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-outline-opacity')
-      ?.updateMeta('utilities', 'outline', pluginOrder.outline, 4, true);
-  }
+  return handler.catchPrefix(/^outline-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-outline-opacity')
+    ?.updateMeta('utilities', 'outline', pluginOrder.outline, 4, true)
 
-  if (utility.raw.match(/^outline-(solid|dotted)/)) {
-    const newUtility = utility.clone(utility.raw.replace('outline-', ''));
-    const outlineColor = newUtility.handler
-      .handleStatic({ none: 'transparent', white: 'white', black: 'black' })
-      .handleColor()
-      .handleOpacity(theme('opacity'))
-      .handleVariable()
-      .createColorValue('var(--tw-outline-opacity, 1)');
+  || handler.catchPrefix(/^outline-(solid|dotted)/, true)
+    ?.then(() => {
+      const newUtility = utility.clone(utility.raw.replace('outline-', ''));
+      const outlineColor = newUtility.handler
+        .handleStatic({ none: 'transparent', white: 'white', black: 'black' })
+        .handleColor()
+        .handleOpacity(theme('opacity'))
+        .handleVariable()
+        .createColorValue('var(--tw-outline-opacity, 1)');
 
-    if (outlineColor) return new Style(utility.class, [
-      new Property('outline', `2px ${newUtility.identifier} ${outlineColor}`),
-      new Property('outline-offset', '2px') ]
-    ).updateMeta('utilities', 'outline', pluginOrder.outline, 3, true);
-  }
+      if (outlineColor) return new Style(utility.class, [
+        new Property('outline', `2px ${newUtility.identifier} ${outlineColor}`),
+        new Property('outline-offset', '2px') ]
+      ).updateMeta('utilities', 'outline', pluginOrder.outline, 3, true);
+    })
 
-  const handler = utility.handler.handleColor().handleOpacity(theme('opacity')).handleSquareBrackets().handleVariable((variable: string) => utility.raw.startsWith('outline-$') ? `var(--${variable})` : undefined);
-  const color = handler.createColorValue();
-  if (color) return new Style(utility.class, [
-    new Property('outline', `2px ${ handler.value === 'transparent' ? 'solid' : 'dotted'} ${color}`),
-    new Property('outline-offset', '2px'),
-  ])?.updateMeta('utilities', 'outline', pluginOrder.outline, 2, true);
+  || handler.catchPrefix(/^outline/)
+    ?.handleColor()
+    .handleOpacity(theme('opacity'))
+    .handleSquareBrackets()
+    .handleVariable((variable: string) => utility.raw.startsWith('outline-$') ? `var(--${variable})` : undefined)
+    .then(() => {
+      const color = handler.createColorValue();
+      if (color) return new Style(utility.class, [
+        new Property('outline', `2px ${ handler.value === 'transparent' ? 'solid' : 'dotted'} ${color}`),
+        new Property('outline-offset', '2px'),
+      ])?.updateMeta('utilities', 'outline', pluginOrder.outline, 2, true);
+    });
 }
 
 // https://windicss.org/utilities/svg.html#fill-color
 function fill(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('fill-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-fill-opacity')
-      ?.updateMeta('utilities', 'fill', pluginOrder.ringOffsetColor, 2, true);
-  }
-  return utility.handler
-    .handleColor(theme('fill'))
+  return utility.handler.catchPrefix(/^fill-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-fill-opacity')
+    ?.updateMeta('utilities', 'fill', pluginOrder.ringOffsetColor, 2, true)
+
+  || utility.handler.catchPrefix(/^fill/)
+    ?.handleColor(theme('fill'))
     .handleOpacity(theme('opacity'))
     .handleSquareBrackets()
     .handleVariable()
@@ -1464,46 +1485,40 @@ function fill(utility: Utility, { theme }: PluginUtils): Output {
 // https://windicss.org/utilities/svg.html#stroke-color
 // https://windicss.org/utilities/svg.html#stroke-width
 function stroke(utility: Utility, { theme }: PluginUtils): Output {
-  if (utility.raw.startsWith('stroke-dash')) {
-    return utility.handler.handleNumber().createProperty('stroke-dasharray')?.updateMeta('utilities', 'strokeDashArray', pluginOrder.strokeDashArray, 0, true);
-  }
-  if (utility.raw.startsWith('stroke-offset')) {
-    return utility.handler.handleNumber().createProperty('stroke-dashoffset')?.updateMeta('utilities', 'strokeDashOffset', pluginOrder.strokeDashOffset, 0, true);
-  }
+  const handler = utility.handler;
+  return handler.catchPrefix(/^stroke-dash/, true)
+    ?.handleNumber().createProperty('stroke-dasharray')?.updateMeta('utilities', 'strokeDashArray', pluginOrder.strokeDashArray, 0, true)
 
-  if (utility.raw.startsWith('stroke-opacity')) {
-    return utility.handler
-      .handleStatic(theme('opacity'))
-      .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
-      .handleVariable()
-      .createProperty('--tw-stroke-opacity')
-      ?.updateMeta('utilities', 'stroke', pluginOrder.stroke, 2, true);
-  }
-  return utility.handler
-    .handleColor(theme('stroke'))
+  || handler.catchPrefix(/^stroke-offset/, true)
+    ?.handleNumber().createProperty('stroke-dashoffset')?.updateMeta('utilities', 'strokeDashOffset', pluginOrder.strokeDashOffset, 0, true)
+
+  || handler.catchPrefix(/^stroke-opacity/, true)
+    ?.handleStatic(theme('opacity'))
+    .handleNumber(0, 100, 'int', (number: number) => (number / 100).toString())
+    .handleVariable()
+    .createProperty('--tw-stroke-opacity')
+    ?.updateMeta('utilities', 'stroke', pluginOrder.stroke, 2, true)
+
+  || handler.catchPrefix(/^stroke/)
+    ?.handleColor(theme('stroke'))
     .handleOpacity(theme('opacity'))
     .handleVariable()
     .handleSquareBrackets()
     .createColorStyle(utility.class, 'stroke', '--tw-stroke-opacity')
     ?.updateMeta('utilities', 'stroke', pluginOrder.stroke, 1, true)
-  || (utility.raw.startsWith('stroke-$')
-    ? utility.handler
-      .handleVariable()
-      .createProperty('stroke-width')
-      ?.updateMeta('utilities', 'strokeWidth', pluginOrder.strokeWidth, 2, true)
-    : utility.handler
-      .handleStatic(theme('strokeWidth'))
-      .handleNumber(0, undefined, 'int')
-      .createProperty('stroke-width')
-      ?.updateMeta('utilities', 'strokeWidth', pluginOrder.strokeWidth, 1, true)
-  );
+
+  || handler.catchPrefix(/^stroke(-width)?/)
+    ?.handleStatic(theme('strokeWidth'))
+    .handleNumber(0, undefined, 'int')
+    .handleVariable()
+    .createProperty('stroke-width')
+    ?.updateMeta('utilities', 'strokeWidth', pluginOrder.strokeWidth, 1, true);
 }
 
 function content(utility: Utility, { theme }: PluginUtils): Output {
-  if (!utility.raw.startsWith('content-'))
-    return;
   return utility.handler
-    .handleBody(theme('content'))
+    .catchPrefix(/^content/)
+    ?.handleBody(theme('content'))
     .handleSquareBrackets()
     .handleVariable()
     .handleString((string) => `"${string}"`)

--- a/src/lib/utilities/handler.ts
+++ b/src/lib/utilities/handler.ts
@@ -4,8 +4,6 @@ import { toColor } from '../../utils/color';
 import { cssEscape } from '../../utils/algorithm';
 import {
   isNumber,
-  isFraction,
-  isSize,
   roundUp,
   fracToPercent,
   hex2RGB,
@@ -16,16 +14,32 @@ import {
 
 import type { colorCallback, colorObject, DictStr, Handlers } from '../../interfaces';
 
+type emptyCallback = () => Property | Style | Style[] | undefined
+type valueCallback = (value: string) => Property | Style | Style[] | undefined
+type handlerCallback = (handler: Handler) => Property | Style | Style[] | undefined
+
 export type Handler = {
   utility: Utility
   value?: string
+  prefix?: string
   _amount: string
+  _slices: string[]
+  _prefix_expr?: string
   opacity?: string | undefined
   color?: colorCallback
+  catchPrefix: (regex: RegExp, match?: boolean) => Handler | undefined,
+  isStatic: (map: { [key: string]: string | string[] }, amount?: string) => boolean,
+  isTime: (start: number, end: number, type: 'int' | 'float') => boolean,
+  isNumber: (start: number, end: number, type: 'int' | 'float') => boolean,
+  isFraction: () => boolean,
+  isSize: () => boolean,
+  isNxl: () => boolean,
+  isVariable: () => boolean,
+  isSquareBracket: () => boolean,
   handleStatic: (
     map?: { [key: string]: string | string[] } | unknown,
     callback?: (str: string) => string | undefined
-  )=> Handler
+  ) => Handler
   handleBody: (
     map?: { [key: string]: string | string[] } | unknown,
     callback?: (str: string) => string | undefined
@@ -82,9 +96,8 @@ export type Handler = {
     opacityVariable?: string | undefined,
     wrapRGB?: boolean
   ) => Style | undefined
-  callback: (
-    func: (value: string) => Property | Style | Style[] | undefined
-  ) => Property | Style | Style[] | undefined
+  callback: (func: valueCallback) => Property | Style | Style[] | undefined
+  then: (func: (handlerCallback | emptyCallback)) => Property | Style | Style[] | undefined
 }
 
 export type HandlerCreator = (utility: Utility, value?: string | undefined, color?: colorCallback | undefined) => Handler;
@@ -96,13 +109,87 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
       value,
       color,
       _amount: utility.amount,
+      _slices: utility.slices,
+
+      catchPrefix: (regex, match = false) => {
+        handler._prefix_expr = regex.source;
+
+        if (match) {
+          const matched = utility.raw.match(regex);
+          if (!matched) return;
+          handler.prefix = matched[0];
+        }
+        return handler;
+      },
+
+      isStatic: (map, amount = handler._amount) => {
+        return amount in map && new RegExp(`${handler._prefix_expr ?? ''}-?${amount}$`).test(handler.utility.raw);
+      },
+
+      isNumber: (
+        start = -Infinity,
+        end = Infinity,
+        type = 'int'
+      ) => {
+        const prefix = handler._prefix_expr;
+        const utility = handler.utility.raw;
+        if (!prefix) return isNumber(handler._amount, start, end, type);
+        const isInt = new RegExp(`${prefix}-\\d+$`).test(utility);
+        if (type === 'int') {
+          if (!isInt) return false;
+        } else {
+          const isFloat = new RegExp(`${prefix}-\\d+\\.\\d+$`).test(utility);
+          if (!(isInt || isFloat)) return false;
+        }
+        const num = parseFloat(handler._amount);
+        return num >= start && num <= end;
+      },
+
+      isTime: (
+        start = -Infinity,
+        end = Infinity,
+        type = 'int'
+      ) => {
+        const prefix = handler._prefix_expr;
+        const utility = handler.utility.raw;
+        if (!prefix) return isNumber(handler._amount, start, end, type);
+        const isInt = new RegExp(`${prefix}-\\d+(s|ms)$`).test(utility);
+        if (type === 'int') {
+          if (!isInt) return false;
+        } else {
+          const isFloat = new RegExp(`${prefix}-\\d+\\.\\d+(s|ms)$`).test(utility);
+          if (!(isInt || isFloat)) return false;
+        }
+        const num = parseFloat(handler._amount);
+        return num >= start && num <= end;
+      },
+
+      isFraction: () => {
+        return handler._prefix_expr ? new RegExp(`${handler._prefix_expr}-\\d+\\/\\d+$`).test(handler.utility.raw) : /^\d+\/\d+$/.test(handler._amount);
+      },
+
+      isSize: () => {
+        return handler._prefix_expr ? new RegExp(`${handler._prefix_expr}-(\\d+(\\.\\d+)?)+(rem|em|px|rpx|vh|vw|ch|ex)$`).test(handler.utility.raw) : /^-?(\d+(\.\d+)?)+(rem|em|px|rpx|vh|vw|ch|ex)$/.test(handler._amount);
+      },
+
+      isNxl: () => {
+        return handler._prefix_expr ? new RegExp(`${handler._prefix_expr}-\\d*xl$`).test(handler.utility.raw) : /^\d*xl$/.test(handler._amount);
+      },
+
+      isVariable: () => {
+        return new RegExp(`${handler._prefix_expr ?? ''}-\\$[\\w-]+`).test(handler.utility.raw);
+      },
+
+      isSquareBracket: () => {
+        return new RegExp(`${handler._prefix_expr ?? ''}-\\[.+\\]`).test(handler.utility.raw);
+      },
 
       handleStatic: handlers.static ? (map, callback) => {
         if (handler.value) return handler;
         if (map && typeof map === 'object') {
           const knownMap = map as { [key: string]: string | string[] };
-          if (knownMap.DEFAULT) knownMap[handler.utility.raw] = knownMap.DEFAULT;
-          if (handler._amount in knownMap)
+          if (knownMap.DEFAULT) knownMap[''] = knownMap.DEFAULT;
+          if (handler.isStatic(knownMap))
             handler.value = callback
               ? callback(handler._amount)
               : `${knownMap[handler._amount]}`;
@@ -124,7 +211,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
 
       handleNumber: handlers.number ? (start = -Infinity, end = Infinity, type = 'int', callback) => {
         if (handler.value) return handler;
-        if (isNumber(handler._amount, start, end, type))
+        if (handler.isNumber(start, end, type))
           handler.value = callback ? callback(+handler._amount) : handler._amount;
         return handler;
       } : () => handler,
@@ -154,7 +241,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
 
       handleSquareBrackets: handlers.bracket ? (callback) => {
         if (handler.value) return handler;
-        if (handler._amount[0] === '[' && handler._amount[handler._amount.length-1] === ']') {
+        if (handler._amount[0] === '[' && handler._amount[handler._amount.length-1] === ']' && handler.isSquareBracket()) {
           let value = handler._amount.slice(1, -1).replace(/_/g, ' '); // replace _ to space
           if (value.indexOf('calc(') > -1) {
             value = value.replace(/(-?\d*\.?\d(?!\b-.+[,)](?![^+\-/*])\D)(?:%|[a-z]+)?|\))([+\-/*])/g, '$1 $2 ');
@@ -175,7 +262,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
 
       handleNxl: handlers.nxl ? (callback) => {
         if (handler.value) return handler;
-        if (/^\d*xl$/.test(handler._amount))
+        if (handler.isNxl())
           handler.value = callback
             ? callback(handler._amount === 'xl' ? 1 : parseInt(handler._amount))
             : parseInt(handler._amount).toString();
@@ -184,7 +271,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
 
       handleFraction: handlers.fraction ? (callback) => {
         if (handler.value) return handler;
-        if (isFraction(handler._amount))
+        if (handler.isFraction())
           handler.value = callback
             ? callback(handler._amount)
             : fracToPercent(handler._amount);
@@ -193,7 +280,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
 
       handleSize: handlers.size ? (callback) => {
         if (handler.value) return handler;
-        if (isSize(handler._amount))
+        if (handler.isSize())
           handler.value = callback ? callback(handler._amount) : handler._amount;
         return handler;
       } : () => handler,
@@ -201,7 +288,7 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
       handleVariable: handlers.variable ? (callback) => {
         if (handler.value) return handler;
         const matchVariable = handler.utility.raw.match(/-\$[\w-]+/);
-        if (matchVariable) {
+        if (matchVariable && handler.isVariable()) {
           const variableName = matchVariable[0].substring(2);
           handler.value = callback ? callback(variableName) : `var(--${variableName})`;
         }
@@ -304,6 +391,8 @@ export function createHandler(handlers: Handlers = { static: true }): HandlerCre
         if (!handler.value) return;
         return func(handler.value);
       },
+
+      then: (func) => func(handler),
     };
     return handler;
   };
@@ -342,10 +431,13 @@ export class Utility {
     return this.match(/-.+(?=-)/).substring(1); // real-gray
   }
   get amount(): string {
-    return this.match(/(?:[^-]+|\[[\s\S]*?\])$/); // 300
+    return this.match(/-(?:[^-]+|\[[\s\S]*?\])$/).substring(1); // 300
   }
   get body(): string {
     return this.match(/-.+/).substring(1); // real-gray-300
+  }
+  get slices(): string[] {
+    return this.absolute.split('-'); // ['placeholder', 'real', 'gray', '300']
   }
   get handler(): Handler {
     return this._h(this);

--- a/test/processor/__snapshots__/attributify.test.ts.yml
+++ b/test/processor/__snapshots__/attributify.test.ts.yml
@@ -1597,30 +1597,30 @@ Tools / with margin padding space_between / css / 0: |-
   [m~="4"] {
     margin: 1rem;
   }
-  [m~="x-2"] {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+  [m~="-x-2"] {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
   }
-  [m~="y-3"] {
-    margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
+  [m~="-y-3"] {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem;
   }
-  [m~="t-4"] {
-    margin-top: 1rem;
+  [m~="r-px"] {
+    margin-right: 1px;
   }
   [p~="4"] {
     padding: 1rem;
   }
-  [p~="-x-2"] {
+  [p~="x-2"] {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
-  [p~="-y-3"] {
+  [p~="y-3"] {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;
   }
-  [p~="r-px"] {
-    padding-right: 1px;
+  [p~="t-4"] {
+    padding-top: 1rem;
   }
 Tools / with negative utility / css / 0: |-
   [m~="-x-4"] {

--- a/test/processor/__snapshots__/interpret.test.ts.yml
+++ b/test/processor/__snapshots__/interpret.test.ts.yml
@@ -240,7 +240,7 @@ Tools / interpret square brackets / square brackets / 0: |-
   }
   .border-l-\[\#342\] {
     --tw-border-opacity: 1;
-    border-color: rgba(51, 68, 34, var(--tw-border-opacity));
+    border-left-color: rgba(51, 68, 34, var(--tw-border-opacity));
   }
   .rounded-\[11px\] {
     border-radius: 11px;

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -784,6 +784,9 @@ Tools / content utilities / css / 0: |-
   .after\:content-\[attr\(value\)\]::after {
     content: attr(value);
   }
+  .content {
+    content: "";
+  }
 Tools / content utilities false / css / 0: ''
 Tools / fill-none and stroke-none is wrong / css / 0: |-
   .fill-none {
@@ -882,6 +885,26 @@ Tools / grid template test / grid template / 0: |-
   }
   .grid-rows-4 {
     grid-template-rows: repeat(4, minmax(0, 1fr));
+  }
+Tools / inset exact match / css / 0: |-
+  .inset-auto {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+  .inset-4 {
+    top: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+  .inset-x-13 {
+    right: 3.25rem;
+    left: 3.25rem;
+  }
+  .top-1\/3 {
+    top: 33.333333%;
   }
 Tools / list style type / css / 0: |-
   .list-disc {
@@ -1305,4 +1328,17 @@ Tools / wrap container / small container / 0: |-
         max-width: 1536px;
       }
     }
+  }
+Tools / zIndex exact match / css / 0: |-
+  .z-auto {
+    z-index: auto;
+  }
+  .z-20 {
+    z-index: 20;
+  }
+  .-z-10 {
+    z-index: -10;
+  }
+  .z-\$var-name {
+    z-index: var(--var-name);
   }

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -906,6 +906,13 @@ Tools / inset exact match / css / 0: |-
   .top-1\/3 {
     top: 33.333333%;
   }
+Tools / lineHeight exact match / css / 0: |-
+  .leading-4 {
+    line-height: 1rem;
+  }
+  .leading-\[1\.25rem\] {
+    line-height: 1.25rem;
+  }
 Tools / list style type / css / 0: |-
   .list-disc {
     list-style-type: disc;
@@ -946,6 +953,13 @@ Tools / more color opacity group utilities / css / 0: |-
   .text-stroke-green-500\/50 {
     --tw-text-stroke-opacity: 0.5;
     -webkit-text-stroke-color: rgba(16, 185, 129, var(--tw-text-stroke-opacity));
+  }
+Tools / padding exact match / css / 0: |-
+  .p-4 {
+    padding: 1rem;
+  }
+  .p-12\.5 {
+    padding: 3.125rem;
   }
 Tools / prespective and perspective origin / css / 0: |-
   .perspect-none {

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -787,7 +787,7 @@ Tools / content utilities / css / 0: |-
   .content {
     content: "";
   }
-Tools / content utilities false / css / 0: ''
+Tools / content utilities startsWith symbol / css / 0: ''
 Tools / fill-none and stroke-none is wrong / css / 0: |-
   .fill-none {
     fill: none;

--- a/test/processor/attributify.test.ts
+++ b/test/processor/attributify.test.ts
@@ -315,8 +315,8 @@ describe('Attributify Mode', () => {
 
   it('with margin padding space_between', () => {
     const result = processor.attributify({
-      'm': ['4', 'x-2', 'y-3', 't-4'],
-      'p': ['4', '-x-2', '-y-3', 'r-px'],
+      'p': ['4', 'x-2', 'y-3', 't-4'],
+      'm': ['4', '-x-2', '-y-3', 'r-px'],
       'space': ['x-4', 'y-2', '-x-4'],
     });
     expect(result.ignored.length).toEqual(0);

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -214,7 +214,7 @@ describe('Utilities', () => {
   });
 
   // #216
-  it('content utilities false', () => {
+  it('content utilities startsWith symbol', () => {
     expect(processor.interpret('.content-type .bg-red-100').styleSheet.build()).toMatchSnapshot('css');
   });
 
@@ -366,5 +366,13 @@ describe('Utilities', () => {
 
   it('fill-none and stroke-none is wrong', () => {
     expect(processor.interpret('fill-none stroke-none').styleSheet.build()).toMatchSnapshot('css');
+  });
+
+  it('inset exact match', () => {
+    expect(processor.interpret('inset-auto inset-sth-auto inset-4 inset-x-13 inset-x-sth-13 top-1/3 top-sth-1/3 top-sth-4/15 inset-y-sth-3.5rem inset-sth-[3.5rem] inset-sth-$var-name').styleSheet.build()).toMatchSnapshot('css');
+  });
+
+  it('zIndex exact match', () => {
+    expect(processor.interpret('z-auto z-20 -z-10 z-$var-name z-sth-auto, z-sth-20 -z-sth-10 z-sth-42 -z-sth-42 -z-sth-$var-name').styleSheet.build()).toMatchSnapshot('css');
   });
 });

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -375,4 +375,13 @@ describe('Utilities', () => {
   it('zIndex exact match', () => {
     expect(processor.interpret('z-auto z-20 -z-10 z-$var-name z-sth-auto, z-sth-20 -z-sth-10 z-sth-42 -z-sth-42 -z-sth-$var-name').styleSheet.build()).toMatchSnapshot('css');
   });
+
+  it('padding exact match', () => {
+    expect(processor.interpret('p-4 p-12.5 p-what-ever-2 p-what-ever-[2rem] p-sth-$var-name p-col-12').styleSheet.build()).toMatchSnapshot('css');
+  });
+
+  it('lineHeight exact match', () => {
+    expect(processor.interpret('leading-4 leading-[1.25rem] leading-any-thing-4 leading-any-thing-[1.25rem] ').styleSheet.build()).toMatchSnapshot('css');
+  });
+  // TODO: we need more tests for exact matching
 });


### PR DESCRIPTION
This pull request fixes the problems described in #484.

Added the `catchPrefix` method to dynamically generate the corresponding regular expression with prefix when matching numbers or fraction, etc., so that absolute precision can be achieved.