### PR TITLE
fix: move Console to utils/tools, so cli/utils isnt build into main entry

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 import arg from 'arg';
-import { deepCopy } from '../utils/tools';
+import { deepCopy, Console } from '../utils/tools';
 import { resolve, dirname, join, extname } from 'path';
 import { Processor } from '../lib';
 import { readFileSync, writeFile, watch, unwatchFile, existsSync } from 'fs';
@@ -9,7 +9,6 @@ import {
   getVersion,
   globArray,
   generateTemplate,
-  Console,
   fuzzy,
 } from './utils';
 import type { Extractor } from '../interfaces';

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -3,25 +3,6 @@ import path from 'path';
 import glob from 'glob';
 import minimatch from 'minimatch';
 
-export class Console {
-  static log(...message: unknown[]): void {
-    // eslint-disable-next-line no-console
-    console.log(...message);
-  }
-  static error(...message: unknown[]): void {
-    // eslint-disable-next-line no-console
-    console.error(...message);
-  }
-  static time(label?: string): void {
-    // eslint-disable-next-line no-console
-    console.time(label);
-  }
-  static timeEnd(label?: string): void {
-    // eslint-disable-next-line no-console
-    console.timeEnd(label);
-  }
-}
-
 export function globArray(patterns: string[], options?: glob.IOptions): string[] {
   const list: string[] = [];
 

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -1,4 +1,4 @@
-import { Console } from '../cli/utils';
+import { Console } from '../utils/tools';
 
 type Colors =
   'black'

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,5 +1,24 @@
 import type { colorCallback, colorObject } from '../interfaces';
 
+export class Console {
+  static log(...message: unknown[]): void {
+    // eslint-disable-next-line no-console
+    console.log(...message);
+  }
+  static error(...message: unknown[]): void {
+    // eslint-disable-next-line no-console
+    console.error(...message);
+  }
+  static time(label?: string): void {
+    // eslint-disable-next-line no-console
+    console.time(label);
+  }
+  static timeEnd(label?: string): void {
+    // eslint-disable-next-line no-console
+    console.timeEnd(label);
+  }
+}
+
 export type Arrayable<T> = T | T[]
 
 export function toArray<T>(v: Arrayable<T>): T[] {


### PR DESCRIPTION
Console is now used in https://github.com/windicss/windicss/blob/d827f96ab1eb6609bd6500c9a735d722d0588063/src/config/colors.ts#L1
therefore, when building, the complete cli/utils.ts gets included
and you cant use windicss in the browser anymore, because of the imports (fs, path, glob, minimatch)
so moving Console to utils/tools to fix this