### PR TITLE
fix: create output directory when it doesn't exist

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -257,8 +257,7 @@ function build(files: string[], update = false) {
         .combine()
         .extend(outputStyle);
     const filePath = args['--output'] ?? 'windi.css';
-    const parts = filePath.split('/');
-    const dir = parts.slice(0, parts.length - 1).join('/');
+    const dir = dirname(filePath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     writeFile(filePath, outputStyle.build(args['--minify']), () => null);
     if (!update) {


### PR DESCRIPTION
Splits the `filePath` up and recursively attempts to create the specified directory

Fixes: https://github.com/windicss/windicss/issues/431