### PR TITLE
fix: skip empty content utility

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1500,7 +1500,7 @@ function stroke(utility: Utility, { theme }: PluginUtils): Output {
 }
 
 function content(utility: Utility, { theme }: PluginUtils): Output {
-  if (!utility.raw.startsWith('content-'))
+  if (!/^content-(?!$)/.test(utility.raw))
     return;
   return utility.handler
     .handleBody(theme('content'))

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -210,7 +210,7 @@ describe('Utilities', () => {
   });
 
   it('content utilities', () => {
-    expect(processor.interpret('content-👍 before:content-["👍"] content-open-quote after:content-[attr(value)] content').styleSheet.build()).toMatchSnapshot('css');
+    expect(processor.interpret('content-👍 before:content-["👍"] content-open-quote after:content-[attr(value)] content content-').styleSheet.build()).toMatchSnapshot('css');
   });
 
   // #216


### PR DESCRIPTION
https://github.com/windicss/vite-plugin-windicss/pull/252

`content-` should not output, use `content-DEFAULT` instead.