### PR TITLE
fix: add default content to pseudo element with `contents`

### DIFF
--- a/src/config/base.ts
+++ b/src/config/base.ts
@@ -1,6 +1,7 @@
 import { colors } from './colors';
 import { keyframes } from './keyframes';
 import { variantOrder } from './order';
+import plugin from '../plugin';
 import type { Config } from '../interfaces';
 
 export const defaultColors = {
@@ -1228,7 +1229,24 @@ export const baseConfig: Config = {
     },
   },
   variantOrder: variantOrder,
-  plugins: [],
+  plugins: [
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        '.before\\:contents': {
+          '&::before': {
+            content: '""',
+            display: 'contents',
+          },
+        },
+        '.after\\:contents': {
+          '&::after': {
+            content: '""',
+            display: 'contents',
+          },
+        },
+      });
+    }),
+  ],
   handlers: {
     static : true,
     time: true,

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -775,6 +775,15 @@ Tools / container padding / container padding / 0: |-
       max-width: 1536px;
     }
   }
+Tools / content pseudo elements / css / 0: |-
+  .before\:contents::before {
+    content: "";
+    display: contents;
+  }
+  .after\:contents::after {
+    content: "";
+    display: contents;
+  }
 Tools / content utilities / css / 0: |-
   .content-👍 {
     content: "👍";

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -213,6 +213,10 @@ describe('Utilities', () => {
     expect(processor.interpret('content-👍 before:content-["👍"] content-open-quote after:content-[attr(value)] content').styleSheet.build()).toMatchSnapshot('css');
   });
 
+  it('content pseudo elements', () => {
+    expect(processor.interpret('before:contents after:contents').styleSheet.build()).toMatchSnapshot('css');
+  });
+
   // #216
   it('content utilities false', () => {
     expect(processor.interpret('.content-type .bg-red-100').styleSheet.build()).toMatchSnapshot('css');


### PR DESCRIPTION
https://github.com/windicss/vite-plugin-windicss/pull/252

tailwind will auto add `content: ""` to *pseudo*:contents:
```css
/* contents */
.contents {
    display: contents;
}

/* after:contents */
.after\:contents::after {
    content: "";
    display: contents;
}
```

I'm not sure it's fit to resolve this by adding a plugin in the default config.