### PR TITLE
Add 'scroll-snap-align: none' utility class

### DIFF
--- a/src/plugin/scroll-snap/index.ts
+++ b/src/plugin/scroll-snap/index.ts
@@ -36,6 +36,10 @@ export default plugin(
         ])
       ),
 
+      '.snap-align-none': {
+        'scroll-snap-align': 'none',
+      },
+
       // scroll-snap-type
       '.snap': {
         'scroll-snap-type':

--- a/test/plugin/scrollSnap.test.ts
+++ b/test/plugin/scrollSnap.test.ts
@@ -11,6 +11,7 @@ describe('Scroll Snap plugin', () => {
       snap-start
       snap-end
       snap-center
+      snap-align-none
       snap-none
       snap-mandatory
       snap-proximity


### PR DESCRIPTION
This adds the `.snap-align-none` utility class as Windi CSS does not yet support it.

```css
.snap-align-none {
  scroll-snap-align: none;
}
```

#### References

- Windi CSS docs: https://windicss.org/plugins/official/scroll-snap.html
- Tailwind v3 docs https://tailwindcss.com/docs/scroll-snap-align