### PR TITLE
feat: add 'portrait:' and 'landscape:' variants

### DIFF
--- a/src/config/base.ts
+++ b/src/config/base.ts
@@ -59,6 +59,10 @@ export const baseConfig: Config = {
   attributify: false,
   darkMode: 'class', // or 'media'
   theme: {
+    orientation: {
+      portrait: 'portrait',
+      landscape: 'landscape',
+    },
     screens: {
       sm: '640px',
       md: '768px',

--- a/src/config/order.ts
+++ b/src/config/order.ts
@@ -60,8 +60,6 @@ export const variantOrder = [
   'motion-reduce',
 ];
 
-
-
 export enum layerOrder {
   base = 10,
   components = 150,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -97,6 +97,7 @@ export type ThemeType = ConfigUtil | Record<string, any> | undefined
 
 export interface BaseTheme {
   vars: ThemeType
+  orientation: ThemeType
   screens: ThemeType
   colors: ThemeType
   spacing: ThemeType
@@ -252,7 +253,7 @@ export type Handlers = {
 
 export type StyleArrayObject = { [key: string]: Style[] }
 export type ResolvedVariants = { [key: string]: () => Style }
-export type VariantTypes = 'screen' | 'theme' | 'state'
+export type VariantTypes = 'screen' | 'theme' | 'state' | 'orientation'
 export type AddPluginType = 'static' | 'utilities' | 'components' | 'preflights' | 'shortcuts'
 
 export interface ExtractorResultDetailed {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -234,7 +234,7 @@ export class Processor {
     if (type) {
       return variants[type];
     }
-    return { ...variants.screen, ...variants.theme, ...variants.state };
+    return { ...variants.screen, ...variants.theme, ...variants.state, ...variants.orientation };
   }
 
   resolveStaticUtilities(includePlugins = false): StyleArrayObject {

--- a/src/lib/variants/index.ts
+++ b/src/lib/variants/index.ts
@@ -1,3 +1,4 @@
+import { generateOrientations } from './orientation';
 import { generateScreens } from './screen';
 import { generateThemes } from './theme';
 import { generateStates } from './state';
@@ -6,6 +7,7 @@ import type { Style } from '../../utils/style';
 import type { BaseTheme, Config, DictStr } from '../../interfaces';
 
 export type Variants = {
+  orientation: { [key: string]: () => Style };
   screen: { [key: string]: () => Style };
   theme: { [key: string]: () => Style };
   state: { [key: string]: () => Style };
@@ -13,6 +15,7 @@ export type Variants = {
 
 export function resolveVariants(config: Config): Variants {
   return {
+    orientation: generateOrientations(((config.theme as BaseTheme)?.orientation ?? {})),
     screen: generateScreens(((config.theme as BaseTheme)?.screens ?? {}) as DictStr),
     theme: generateThemes(config.darkMode),
     state: generateStates(config.variantOrder ?? []),
@@ -20,6 +23,7 @@ export function resolveVariants(config: Config): Variants {
 }
 
 export {
+  generateOrientations,
   generateScreens,
   generateThemes,
   generateStates,

--- a/src/lib/variants/orientation.ts
+++ b/src/lib/variants/orientation.ts
@@ -1,0 +1,13 @@
+import { Style } from '../../utils/style';
+
+export function generateOrientations(orientations: {
+  [key: string]: string
+}): { [key: string]: () => Style } {
+  const variants : { [key: string]: () => Style } = {};
+
+  Object.entries(orientations).forEach(([name, orientation]) => {
+    variants[name] = () => new Style().atRule(`@media (orientation: ${orientation})`);
+  });
+
+  return variants;
+}

--- a/test/processor/__snapshots__/variant.test.ts.yml
+++ b/test/processor/__snapshots__/variant.test.ts.yml
@@ -126,6 +126,11 @@ Tools / generate themes with darkMode media / vars / 0: |-
     "dark": "@media (prefers-color-scheme: dark) {\n  .test {\n    background: #1C1C1E;\n  }\n}",
     "light": "@media (prefers-color-scheme: light) {\n  .test {\n    background: #1C1C1E;\n  }\n}"
   }
+Tools / orientation / css / 0: |-
+  {
+    "portrait": "@media (orientation: portrait) {\n  .test {\n    background: #1C1C1E;\n  }\n}",
+    "landscape": "@media (orientation: landscape) {\n  .test {\n    background: #1C1C1E;\n  }\n}"
+  }
 Tools / resolve variants / screen / 0: |-
   [
     "sm",

--- a/test/processor/resolve.test.ts
+++ b/test/processor/resolve.test.ts
@@ -36,8 +36,10 @@ describe('Resolve Tests', () => {
       'motion-safe',       'motion-reduce',
     ];
     const themeVariants = [ '@dark', '@light', '.dark', '.light', 'dark', 'light' ];
+    const orientationVariants = ['portrait', 'landscape'];
 
-    expect(Object.keys(processor.resolveVariants())).toEqual([...screenVariants, ...themeVariants, ...stateVariants]);
+    expect(Object.keys(processor.resolveVariants())).toEqual([...screenVariants, ...themeVariants, ...stateVariants, ...orientationVariants]);
+    expect(Object.keys(processor.resolveVariants('orientation'))).toEqual(orientationVariants);
     expect(Object.keys(processor.resolveVariants('screen'))).toEqual(screenVariants);
     expect(Object.keys(processor.resolveVariants('theme'))).toEqual(themeVariants);
     expect(Object.keys(processor.resolveVariants('state'))).toEqual(stateVariants);

--- a/test/processor/variant.test.ts
+++ b/test/processor/variant.test.ts
@@ -2,6 +2,7 @@ import { Property } from '../../src/utils/style';
 import type { Style } from '../../src/utils/style';
 import { baseConfig } from '../../src/config';
 import {
+  generateOrientations,
   generateScreens,
   generateStates,
   generateThemes,
@@ -69,7 +70,7 @@ describe('Variants', () => {
 
   it('resolve variants', () => {
     const variants = resolveVariants(baseConfig);
-    expect(Object.keys(variants)).toEqual(['screen', 'theme', 'state']);
+    expect(Object.keys(variants)).toEqual(['orientation', 'screen', 'theme', 'state']);
     expect(Object.keys(variants.screen)).toMatchSnapshot('screen');
     expect(Object.keys(variants.theme)).toEqual([
       '@dark',
@@ -80,8 +81,10 @@ describe('Variants', () => {
       'light',
     ]);
     expect(Object.keys(variants.state)).toEqual(baseConfig.variantOrder ?? []);
+    expect(Object.keys(variants.orientation)).toEqual(['portrait', 'landscape']);
 
     const emptyVariants = resolveVariants({});
+    expect(emptyVariants.orientation).toEqual({});
     expect(emptyVariants.screen).toEqual({});
     expect(emptyVariants.theme).toEqual({});
     expect(emptyVariants.state).toEqual({});
@@ -95,5 +98,14 @@ describe('Variants', () => {
   it('directions', () => {
     const processor = new Processor();
     expect(processor.interpret('ltr:text-lg rtl:dark:text-sm').styleSheet.build()).toMatchSnapshot('css');
+  });
+
+  it('orientation', () => {
+    const processor = new Processor();
+    const orientations = generateOrientations({
+      portrait: 'portrait',
+      landscape: 'landscape',
+    });
+    expect(_generateTestVariants(orientations)).toMatchSnapshot('css');
   });
 });

--- a/test/processor/variant.test.ts
+++ b/test/processor/variant.test.ts
@@ -101,7 +101,6 @@ describe('Variants', () => {
   });
 
   it('orientation', () => {
-    const processor = new Processor();
     const orientations = generateOrientations({
       portrait: 'portrait',
       landscape: 'landscape',


### PR DESCRIPTION
This adds the `portrait:` and `landscape:` variants.

#### Reference

- https://tailwindcss.com/docs/hover-focus-and-other-states#viewport-orientation