### PR TITLE
feat: add ability to use opacity values for box-shadows

### DIFF
--- a/src/config/base.ts
+++ b/src/config/base.ts
@@ -419,16 +419,6 @@ export const baseConfig: Config = {
       8: '8px',
       // int >=0 -> int px
     },
-    boxShadow: {
-      DEFAULT: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
-      sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-      md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
-      lg: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-      xl: '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
-      '2xl': '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-      inner: 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
-      none: 'none',
-    },
     boxShadowColor: (theme) => theme('colors'),
     brightness: {
       0: '0',

--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1200,24 +1200,17 @@ function backdrop(utility: Utility, { theme }: PluginUtils): Output {
 
 // https://windicss.org/utilities/effects.html#box-shadow
 function boxShadow(utility: Utility, { theme }: PluginUtils): Output {
-  const body = utility.body || 'DEFAULT';
-  const shadows = toType(theme('boxShadow'), 'object') as { [key: string]: string };
-  if (Object.keys(shadows).includes(body)) {
-    const shadow = shadows[body].replace(/rgba\s*\(\s*0\s*,\s*0\s*,\s*0/g, 'rgba(var(--tw-shadow-color)');
-    return new Style(utility.class, [
-      new Property('--tw-shadow-color', '0, 0, 0'),
-      new Property('--tw-shadow', shadow),
-      new Property(['-webkit-box-shadow', 'box-shadow'], 'var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)'),
-    ]).updateMeta('utilities', 'boxShadow', pluginOrder.boxShadow, 0, true);
-  }
-  // handle shadowColor
-  return utility.handler
+  const color = utility.handler
     .handleColor(theme('boxShadowColor'))
     .handleOpacity(theme('opacity'))
     .handleSquareBrackets()
     .handleVariable()
-    .createColorStyle(utility.class, '--tw-shadow-color', undefined, false)
-    ?.updateMeta('utilities', 'boxShadowColor', pluginOrder.boxShadowColor, 0, true);
+    .createColorValue('1');
+
+  return new Style(utility.class, [
+    new Property('--tw-shadow-color', color),
+    new Property('--tw-shadow', 'var(--tw-shadow-colored)'),
+  ]).updateMeta('utilities', 'boxShadow', pluginOrder.boxShadow, 0, true);
 }
 
 // https://windicss.org/utilities/effects.html#opacity

--- a/src/lib/utilities/static.ts
+++ b/src/lib/utilities/static.ts
@@ -75,6 +75,104 @@ export const staticUtilities: StaticUtility = {
     },
   },
 
+  // https://windicss.org/utilities/effects.html#box-shadow
+  'shadow-sm': {
+    'utility': {
+      '--tw-shadow': '0 1px 2px 0 rgb(0 0 0/0.05)',
+      '--tw-shadow-colored': '0 1px 2px 0 var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 1,
+    },
+  },
+  'shadow': {
+    'utility': {
+      '--tw-shadow': '0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1)',
+      '--tw-shadow-colored': '0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 2,
+    },
+  },
+  'shadow-md': {
+    'utility': {
+      '--tw-shadow': '0 4px 6px -1px rgb(0 0 0/0.1),0 2px 4px -2px rgb(0 0 0/0.1)',
+      '--tw-shadow-colored': '0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 3,
+    },
+  },
+  'shadow-lg': {
+    'utility': {
+      '--tw-shadow': '0 10px 15px -3px rgb(0 0 0/0.1),0 4px 6px -4px rgb(0 0 0/0.1)',
+      '--tw-shadow-colored': '0 10px 15px -3px var(--tw-shadow-color),0 4px 6px -4px var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 4,
+    },
+  },
+  'shadow-xl': {
+    'utility': {
+      '--tw-shadow': '0 20px 25px -5px rgb(0 0 0/0.1),0 8px 10px -6px rgb(0 0 0/0.1)',
+      '--tw-shadow-colored': '0 20px 25px -5px var(--tw-shadow-color),0 8px 10px -6px var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 5,
+    },
+  },
+  'shadow-2xl': {
+    'utility': {
+      '--tw-shadow': '0 25px 50px -12px rgb(0 0 0/0.25)',
+      '--tw-shadow-colored': '0 25px 50px -12px var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 6,
+    },
+  },
+  'shadow-inner': {
+    'utility': {
+      '--tw-shadow': 'inset 0 2px 4px 0 rgb(0 0 0/0.05)',
+      '--tw-shadow-colored': 'inset 0 2px 4px 0 var(--tw-shadow-color)',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 7,
+    },
+  },
+  'shadow-none': {
+    'utility': {
+      '--tw-shadow': '0 0 #0000',
+      '--tw-shadow-colored': '0 0 #0000',
+      '-webkit-box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+      'box-shadow': 'var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)',
+    },
+    'meta': {
+      'group': 'boxShadow',
+      'order': 8,
+    },
+  },
+
   // https://windicss.org/utilities/display.html
   'block': {
     'utility': {

--- a/src/utils/completions.ts
+++ b/src/utils/completions.ts
@@ -507,6 +507,16 @@ const utilities: { [key:string]: string[]} = {
     'scroll-auto',
     'scroll-smooth',
   ],
+  shadow: [
+    'shadow',
+    'shadow-sm',
+    'shadow-md',
+    'shadow-lg',
+    'shadow-xl',
+    'shadow-2xl',
+    'shadow-inner',
+    'shadow-none',
+  ],
 };
 
 const negative: { [key:string]: true} = {

--- a/test/processor/__snapshots__/attributify.test.ts.yml
+++ b/test/processor/__snapshots__/attributify.test.ts.yml
@@ -163,10 +163,10 @@ Tools / important test / css / 0: |-
     line-height: 1.75rem;
   }
   [\!shadow="lg"] {
-    --tw-shadow-color: 0, 0, 0 !important;
-    --tw-shadow: 0 10px 15px -3px rgba(var(--tw-shadow-color), 0.1), 0 4px 6px -2px rgba(var(--tw-shadow-color), 0.05) !important;
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow) !important;
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow) !important;
+    --tw-shadow: 0 10px 15px -3px rgb(0 0 0/0.1),0 4px 6px -4px rgb(0 0 0/0.1) !important;
+    --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color),0 4px 6px -4px var(--tw-shadow-color) !important;
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow) !important;
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow) !important;
   }
   [\!ring="!opacity-50"] {
     --tw-ring-opacity: 0.5 !important;
@@ -303,10 +303,10 @@ Tools / replace default with ~ / css / 0: |-
     display: grid;
   }
   [shadow="~"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 1px 3px 0 rgba(var(--tw-shadow-color), 0.1), 0 1px 2px 0 rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: 0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   [ring="~"] {
     --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
@@ -881,14 +881,15 @@ Tools / with box utility / css / 0: |-
     -webkit-box-sizing: content-box;
     box-sizing: content-box;
   }
-  [box~="shadow"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 1px 3px 0 rgba(var(--tw-shadow-color), 0.1), 0 1px 2px 0 rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  }
   [box~="shadow-gray-200"] {
-    --tw-shadow-color: 229, 231, 235;
+    --tw-shadow-color: rgba(229, 231, 235, 1);
+    --tw-shadow: var(--tw-shadow-colored);
+  }
+  [box~="shadow"] {
+    --tw-shadow: 0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
 Tools / with caret utility / css / 0: |-
   [caret~="black"] {
@@ -2095,38 +2096,39 @@ Tools / with ring utility / css / 0: |-
     --tw-ring-opacity: 0.5;
   }
 Tools / with shadow utility / css / 0: |-
-  [shadow~="default"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 1px 3px 0 rgba(var(--tw-shadow-color), 0.1), 0 1px 2px 0 rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  [shadow~="gray-400"] {
+    --tw-shadow-color: rgba(156, 163, 175, 1);
+    --tw-shadow: var(--tw-shadow-colored);
   }
   [shadow~="sm"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 1px 2px 0 rgba(var(--tw-shadow-color), 0.05);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: 0 1px 2px 0 rgb(0 0 0/0.05);
+    --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+  }
+  [shadow~="default"] {
+    --tw-shadow: 0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   [shadow~="md"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 4px 6px -1px rgba(var(--tw-shadow-color), 0.1), 0 2px 4px -1px rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1),0 2px 4px -2px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   [shadow~="inner"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: inset 0 2px 4px 0 rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: inset 0 2px 4px 0 rgb(0 0 0/0.05);
+    --tw-shadow-colored: inset 0 2px 4px 0 var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   [shadow~="none"] {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: none;
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  }
-  [shadow~="gray-400"] {
-    --tw-shadow-color: 156, 163, 175;
+    --tw-shadow: 0 0 #0000;
+    --tw-shadow-colored: 0 0 #0000;
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
 Tools / with svg utility / css / 0: |-
   [svg~="fill-current"] {

--- a/test/processor/__snapshots__/config.test.ts.yml
+++ b/test/processor/__snapshots__/config.test.ts.yml
@@ -6,10 +6,10 @@ Tools / allows to use prefix with shortcuts / shortcuts with prefix / 0: |-
     padding-bottom: 0.5rem;
     padding-left: 1rem;
     padding-right: 1rem;
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 4px 6px -1px rgba(var(--tw-shadow-color), 0.1), 0 2px 4px -1px rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1),0 2px 4px -2px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   .windi-btn-green {
     --tw-bg-opacity: 1;
@@ -419,10 +419,10 @@ Tools / shortcuts config string / shortcuts string / 0: |-
     padding-bottom: 0.5rem;
     padding-left: 1rem;
     padding-right: 1rem;
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 4px 6px -1px rgba(var(--tw-shadow-color), 0.1), 0 2px 4px -1px rgba(var(--tw-shadow-color), 0.06);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1),0 2px 4px -2px rgb(0 0 0/0.1);
+    --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
   .btn-green {
     --tw-bg-opacity: 1;
@@ -442,10 +442,10 @@ Tools / shortcuts config string / shortcuts string / 0: |-
       padding-bottom: 0.5rem;
       padding-left: 1rem;
       padding-right: 1rem;
-      --tw-shadow-color: 0, 0, 0;
-      --tw-shadow: 0 4px 6px -1px rgba(var(--tw-shadow-color), 0.1), 0 2px 4px -1px rgba(var(--tw-shadow-color), 0.06);
-      -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-      box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+      --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1),0 2px 4px -2px rgb(0 0 0/0.1);
+      --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color);
+      -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+      box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
     }
   }
 'Tools / support color callback function #75 #256 / css / 0': |-

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -1058,14 +1058,19 @@ Tools / scroll-behavior / css / 0: |-
     scroll-behavior: smooth;
   }
 Tools / shadow color / css / 0: |-
-  .shadow-2xl {
-    --tw-shadow-color: 0, 0, 0;
-    --tw-shadow: 0 25px 50px -12px rgba(var(--tw-shadow-color), 0.25);
-    -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  }
   .shadow-red-800 {
-    --tw-shadow-color: 153, 27, 27;
+    --tw-shadow-color: rgba(153, 27, 27, 1);
+    --tw-shadow: var(--tw-shadow-colored);
+  }
+  .shadow-red-800\/50 {
+    --tw-shadow-color: rgba(153, 27, 27, 0.5);
+    --tw-shadow: var(--tw-shadow-colored);
+  }
+  .shadow-2xl {
+    --tw-shadow: 0 25px 50px -12px rgb(0 0 0/0.25);
+    --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
+    -webkit-box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
   }
 Tools / stroke svg / css / 0: |-
   .stroke-gray-200 {

--- a/test/processor/resolve.test.ts
+++ b/test/processor/resolve.test.ts
@@ -46,8 +46,8 @@ describe('Resolve Tests', () => {
   });
 
   it('resolve static utilities', () => {
-    expect(Object.keys(processor.resolveStaticUtilities(false)).length).toEqual(338);
-    expect(Object.keys(processor.resolveStaticUtilities(true)).length).toEqual(347);
+    expect(Object.keys(processor.resolveStaticUtilities(false)).length).toEqual(346);
+    expect(Object.keys(processor.resolveStaticUtilities(true)).length).toEqual(355);
   });
 
   it('resolve dynamic utilities', () => {

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -172,7 +172,11 @@ describe('Utilities', () => {
   });
 
   it('shadow color', () => {
-    expect(processor.interpret('shadow-2xl shadow-red-800').styleSheet.build()).toMatchSnapshot('css');
+    expect(processor.interpret(`
+    shadow-2xl 
+    shadow-red-800
+    shadow-red-800/50
+    `).styleSheet.build()).toMatchSnapshot('css');
   });
 
   it('caret color', () => {

--- a/test/utils/__snapshots__/completions.test.ts.yml
+++ b/test/utils/__snapshots__/completions.test.ts.yml
@@ -6499,14 +6499,6 @@ Tools / completions / static / 0: |-
     "ring-95",
     "ring-100",
     "ring",
-    "shadow",
-    "shadow-sm",
-    "shadow-md",
-    "shadow-lg",
-    "shadow-xl",
-    "shadow-2xl",
-    "shadow-inner",
-    "shadow-none",
     "opacity-0",
     "opacity-5",
     "opacity-10",
@@ -7021,7 +7013,15 @@ Tools / completions / static / 0: |-
     "touch-pinch-zoom",
     "touch-manipulation",
     "scroll-auto",
-    "scroll-smooth"
+    "scroll-smooth",
+    "shadow",
+    "shadow-sm",
+    "shadow-md",
+    "shadow-lg",
+    "shadow-xl",
+    "shadow-2xl",
+    "shadow-inner",
+    "shadow-none"
   ]
 'Tools / custom theme properties #226 / css / 1': |-
   .h-screen-px {


### PR DESCRIPTION
This adds the ability to use classes like `.shadow-red-800/50`

@antfu This should be the last PR to bring Windi up-to-date with Tailwind v3 (for now)