### PR TITLE
feat: add 'file:' variant

### DIFF
--- a/src/config/order.ts
+++ b/src/config/order.ts
@@ -44,6 +44,7 @@ export const variantOrder = [
   'first-letter',
   'first-line',
   'file-selector-button',
+  'file',
   'selection',
   'svg',
   'all',

--- a/src/lib/variants/state.ts
+++ b/src/lib/variants/state.ts
@@ -60,6 +60,7 @@ export function generateStates (
     'first-letter': () => new Style().pseudoElement('first-letter'),
     'first-line': () => new Style().pseudoElement('first-line'),
     'file-selector-button': () => new Style().pseudoElement('file-selector-button'),
+    file: () => new Style().pseudoElement('file-selector-button'),
     selection: () => new Style().pseudoElement('selection'),
 
     svg: () => new Style().child('svg'),

--- a/test/processor/__snapshots__/variant.test.ts.yml
+++ b/test/processor/__snapshots__/variant.test.ts.yml
@@ -84,6 +84,7 @@ Tools / generate states / all / 0: |-
     "first-letter": ".test::first-letter {\n  background: #1C1C1E;\n}",
     "first-line": ".test::first-line {\n  background: #1C1C1E;\n}",
     "file-selector-button": ".test::file-selector-button {\n  background: #1C1C1E;\n}",
+    "file": ".test::file-selector-button {\n  background: #1C1C1E;\n}",
     "selection": ".test::selection {\n  background: #1C1C1E;\n}",
     "svg": ".test svg {\n  background: #1C1C1E;\n}",
     "all": ".test * {\n  background: #1C1C1E;\n}",

--- a/test/processor/resolve.test.ts
+++ b/test/processor/resolve.test.ts
@@ -29,11 +29,11 @@ describe('Resolve Tests', () => {
       'even-of-type',      'odd-of-type',      'root',
       'empty',             'before',           'after',
       'first-letter',      'first-line',       'file-selector-button',
-      'selection',         'svg',              'all',
-      'children',          'siblings',         'sibling',
-      'ltr',               'rtl',              'group-hover',
-      'group-focus',       'group-active',     'group-visited',
-      'motion-safe',       'motion-reduce',
+      'file',              'selection',        'svg',
+      'all',               'children',         'siblings',
+      'sibling',           'ltr',              'rtl',
+      'group-hover',       'group-focus',      'group-active',
+      'group-visited',     'motion-safe',      'motion-reduce',
     ];
     const themeVariants = [ '@dark', '@light', '.dark', '.light', 'dark', 'light' ];
     const orientationVariants = ['portrait', 'landscape'];


### PR DESCRIPTION
This PR adds the `file:` variant. Windi already provides this functionality via the `file-selector-button:` variant. I kept this variant to be backwards compatible.

#### Reference

- https://tailwindcss.com/docs/hover-focus-and-other-states#file-input-buttons