### PR TITLE
feat: add '.accent-x' utility class

### DIFF
--- a/src/config/order.ts
+++ b/src/config/order.ts
@@ -242,4 +242,5 @@ export enum pluginOrder {
   'willChange' = 14200,
   'touchAction' = 14300,
   'scrollBehavior' = 14400,
+  'accentColor' = 14500,
 }

--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1575,9 +1575,8 @@ function accent(utility:Utility, { theme }: PluginUtils): Output {
     .handleVariable()
     .createColorValue('1');
 
-  return new Style(utility.class, [
-    new Property('accent-color', color),
-  ]).updateMeta('utilities', 'accentColor', pluginOrder.accentColor, 0, true);
+  return new Style(utility.class, new Property('accent-color', color))
+    .updateMeta('utilities', 'accentColor', pluginOrder.accentColor, 0, true);
 }
 
 export const dynamicUtilities: DynamicUtility = {

--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -1566,6 +1566,20 @@ function content(utility: Utility, { theme }: PluginUtils): Output {
     ?.updateMeta('utilities', 'content', pluginOrder.content, 1, true);
 }
 
+// https://windicss.org/utilities/behaviors.html#accent-color
+function accent(utility:Utility, { theme }: PluginUtils): Output {
+  const color = utility.handler
+    .handleColor(theme('boxShadowColor'))
+    .handleOpacity(theme('opacity'))
+    .handleSquareBrackets()
+    .handleVariable()
+    .createColorValue('1');
+
+  return new Style(utility.class, [
+    new Property('accent-color', color),
+  ]).updateMeta('utilities', 'accentColor', pluginOrder.accentColor, 0, true);
+}
+
 export const dynamicUtilities: DynamicUtility = {
   columns: columns,
   container: container,
@@ -1650,4 +1664,5 @@ export const dynamicUtilities: DynamicUtility = {
   delay: delay,
   content: content,
   animate: animation,
+  accent: accent,
 };

--- a/test/processor/__snapshots__/resolve.test.ts.yml
+++ b/test/processor/__snapshots__/resolve.test.ts.yml
@@ -173,7 +173,8 @@ Tools / get corePlugins / list / 0: |-
     "backdropSepia",
     "willChange",
     "touchAction",
-    "scrollBehavior"
+    "scrollBehavior",
+    "accentColor"
   ]
 Tools / get corePlugins / list2 / 1: |-
   [
@@ -353,7 +354,8 @@ Tools / get corePlugins / list3 / 2: |-
     "backdropSepia",
     "willChange",
     "touchAction",
-    "scrollBehavior"
+    "scrollBehavior",
+    "accentColor"
   ]
 Tools / resolve dynamic utilities / with-plugins / 1: |-
   [
@@ -440,6 +442,7 @@ Tools / resolve dynamic utilities / with-plugins / 1: |-
     "delay",
     "content",
     "animate",
+    "accent",
     "filter",
     "aspect-w",
     "aspect-h",
@@ -531,5 +534,6 @@ Tools / resolve dynamic utilities / without-plugins / 0: |-
     "duration",
     "delay",
     "content",
-    "animate"
+    "animate",
+    "accent"
   ]

--- a/test/processor/__snapshots__/utilities.test.ts.yml
+++ b/test/processor/__snapshots__/utilities.test.ts.yml
@@ -1,3 +1,16 @@
+Tools / accent-color / css / 0: |-
+  .accent-green-500\/50 {
+    accent-color: rgba(16, 185, 129, 0.5);
+  }
+  .accent-red-500\/50 {
+    accent-color: rgba(239, 68, 68, 0.5);
+  }
+  .accent-green-500 {
+    accent-color: rgba(16, 185, 129, 1);
+  }
+  .accent-red-500 {
+    accent-color: rgba(239, 68, 68, 1);
+  }
 Tools / animation / animation / 0: |-
   @keyframes spin {
     from {

--- a/test/processor/utilities.test.ts
+++ b/test/processor/utilities.test.ts
@@ -436,4 +436,13 @@ describe('Utilities', () => {
     basis-1/2
     `).styleSheet.build()).toMatchSnapshot('css');
   });
+
+  it('accent-color', () => {
+    expect(processor.interpret(`
+    accent-green-500/50
+    accent-red-500/50
+    accent-green-500
+    accent-red-500
+    `).styleSheet.build()).toMatchSnapshot('css');
+  });
 });


### PR DESCRIPTION
This PR adds the `.accent-x` utility class which allows the user to control the `accent-color` CSS property.

#### Reference

- https://tailwindcss.com/docs/accent-color
- https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color