### PR TITLE
fix: StyleSheet sort makes plugin doesn't work as expected (#666)

### DIFF
--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -13,6 +13,7 @@ export default function preflight(
   // Generate preflight style based on html tags.
   const globalSheet = new StyleSheet();
   const styleSheet = new StyleSheet();
+  const pluginSheet = new StyleSheet();
 
   const createStyle = (
     selector: string | undefined,
@@ -57,16 +58,16 @@ export default function preflight(
     Object.values(processor._plugin.preflights).forEach((styles) => {
       preflightList = preflightList.concat(styles);
     });
-    styleSheet.add(preflightList);
+    pluginSheet.add(preflightList);
 
     // always generated styles
     let staticList: Style[] = [];
     Object.values(processor._plugin.static).forEach((styles) => {
       staticList = staticList.concat(styles);
     });
-    styleSheet.add(staticList);
+    pluginSheet.add(staticList);
   }
 
-  const result = styleSheet.combine().sort();
+  const result = styleSheet.combine().sort().extend(pluginSheet.combine().sort());
   return includeGlobal ? result.extend(globalSheet.combine().sort(), false) : result;
 }


### PR DESCRIPTION
This should fix #666. The solution is create an additional `StyleSheet` for plugin, separate `sort` for each `StyleSheet` then `extend`.