### PR TITLE
fix(jsx): add missing attribute declaration in jsx

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -17,6 +17,7 @@ export type UtilityNames =
   | 'transform'
   | 'align'
   | 'justify'
+  | 'items'
   | 'content'
   | 'pos'
   | 'box'

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -18,6 +18,7 @@ export type UtilityNames =
   | 'align'
   | 'justify'
   | 'items'
+  | 'block'
   | 'content'
   | 'pos'
   | 'box'


### PR DESCRIPTION
<img width="1124" alt="Screen Shot 2022-01-30 at 8 45 52 PM" src="https://user-images.githubusercontent.com/10047788/151700262-5ff48c7e-a745-4d35-a5eb-ddd02bf5fbba.png">
