### PR TITLE
fix(cli): whitespace and line-break support to style block

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -214,7 +214,7 @@ function attributify(files: string[]) {
 function styleBlock(files: string[]) {
   files.forEach((file) => {
     const content = readFileSync(file).toString();
-    const block = content.match(/(?<=<style lang=['"]windi["']>)[\s\S]*(?=<\/style>)/);
+    const block = content.match(/(?<=<style[\r\n]*\s*lang\s?=\s?['"]windi["']>)[\s\S]*(?=<\/style>)/);
     if (block && block.index) {
       const css = content.slice(block.index, block.index + block[0].length);
       const parser = new CSSParser(css, processor);


### PR DESCRIPTION
Previously, I had submitted this PR: https://github.com/windicss/vite-plugin-windicss/pull/257 which enabled me to use syntax like `h = 20`. I tried doing the same with `<style>` block. My code was like:

```HTML
<style
  lang = "windi">
/* some stuff */
</style>
```

This never did anything until I changed my style block to:

```html
<style lang="windi">
/* some stuff */
</style>
```

Because of the `attributify` mode, I'm trying to use all attributes of all tags in a new line to maintain consistency. Thus, when I did the way I did before, it was not working.

This PR changes the style block matching regex to match the above mentioned syntax. Please consider merging it.