### PR TITLE
feat: improve TW3 color support

### DIFF
--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -1,7 +1,10 @@
 import { Console } from '../utils/tools';
 
 type Colors =
-  'black'
+  'inherit'
+  | 'current'
+  | 'transparent'
+  | 'black'
   | 'white'
   | 'rose'
   | 'pink'

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -127,6 +127,9 @@ function color_warn(from: string, to: string) {
 }
 
 export const colors: DefaultColors =  {
+  inherit: 'inherit',
+  current: 'currentColor',
+  transparent: 'transparent',
   black: '#000',
   white: '#fff',
   rose: {

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -121,10 +121,10 @@ let warned = false;
 function color_warn({ from, to }) {
   if (!warned) {
     Console.log(`warn - '${from}' has been renamed to '${to}'.`);
-    Console.log(`warn - Please update your color palette to eliminate this warning.`);
+    Console.log('warn - Please update your color palette to eliminate this warning.');
     warned = true;
-  };
-};
+  }
+}
 
 export const colors: DefaultColors =  {
   black: '#000',
@@ -215,7 +215,7 @@ export const colors: DefaultColors =  {
   },
   sky,
   get lightBlue() {
-    color_warn({ from: "lightBlue", to: "sky" });
+    color_warn({ from: 'lightBlue', to: 'sky' });
     return sky;
   },
   cyan: {
@@ -327,26 +327,26 @@ export const colors: DefaultColors =  {
     900: '#7f1d1d',
   },
   get warmGray() {
-    color_warn({ from: "warmGray", to: "stone" });
+    color_warn({ from: 'warmGray', to: 'stone' });
     return stone;
   },
   get trueGray() {
-    color_warn({ from: "trueGray", to: "neutral" });
+    color_warn({ from: 'trueGray', to: 'neutral' });
     return neutral;
   },
   gray,
   get coolGray() {
-    color_warn({ from: "coolGray", to: "gray" });
+    color_warn({ from: 'coolGray', to: 'gray' });
     return gray;
   },
   get blueGray() {
-    color_warn({ from: "blueGray", to: "slate" });
+    color_warn({ from: 'blueGray', to: 'slate' });
     return slate;
   },
   slate,
   zinc,
   get zink() {
-    color_warn({ from: "zink", to: "zinc" });
+    color_warn({ from: 'zink', to: 'zinc' });
     return zinc;
   },
   neutral,

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -118,7 +118,7 @@ const gray = {
 
 let warned = false;
 
-function color_warn({ from: string, to: string }) {
+function color_warn(from: string, to: string) {
   if (!warned) {
     Console.log(`warn - '${from}' has been renamed to '${to}'.`);
     Console.log('warn - Please update your color palette to eliminate this warning.');
@@ -215,7 +215,7 @@ export const colors: DefaultColors =  {
   },
   sky,
   get lightBlue() {
-    color_warn({ from: 'lightBlue', to: 'sky' });
+    color_warn('lightBlue', 'sky');
     return sky;
   },
   cyan: {
@@ -327,26 +327,26 @@ export const colors: DefaultColors =  {
     900: '#7f1d1d',
   },
   get warmGray() {
-    color_warn({ from: 'warmGray', to: 'stone' });
+    color_warn('warmGray', 'stone');
     return stone;
   },
   get trueGray() {
-    color_warn({ from: 'trueGray', to: 'neutral' });
+    color_warn('trueGray', 'neutral');
     return neutral;
   },
   gray,
   get coolGray() {
-    color_warn({ from: 'coolGray', to: 'gray' });
+    color_warn('coolGray', 'gray');
     return gray;
   },
   get blueGray() {
-    color_warn({ from: 'blueGray', to: 'slate' });
+    color_warn('blueGray', 'slate');
     return slate;
   },
   slate,
   zinc,
   get zink() {
-    color_warn({ from: 'zink', to: 'zinc' });
+    color_warn('zink', 'zinc');
     return zinc;
   },
   neutral,

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -118,7 +118,7 @@ const gray = {
 
 let warned = false;
 
-function color_warn({ from, to }) {
+function color_warn({ from: string, to: string }) {
   if (!warned) {
     Console.log(`warn - '${from}' has been renamed to '${to}'.`);
     Console.log('warn - Please update your color palette to eliminate this warning.');

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -28,6 +28,7 @@ type Colors =
   | 'blueGray'
   | 'slate'
   | 'zink'
+  | 'zinc'
   | 'neutral'
   | 'stone'
   | 'dark'
@@ -50,7 +51,80 @@ const sky = {
   900: '#0c4a6e',
 };
 
+const neutral = {
+  50: '#fafafa',
+  100: '#f5f5f5',
+  200: '#e5e5e5',
+  300: '#d4d4d4',
+  400: '#a3a3a3',
+  500: '#737373',
+  600: '#525252',
+  700: '#404040',
+  800: '#262626',
+  900: '#171717',
+};
+
+const stone = {
+  50: '#fafaf9',
+  100: '#f5f5f4',
+  200: '#e7e5e4',
+  300: '#d6d3d1',
+  400: '#a8a29e',
+  500: '#78716c',
+  600: '#57534e',
+  700: '#44403c',
+  800: '#292524',
+  900: '#1c1917',
+};
+
+const slate = {
+  50: '#f8fafc',
+  100: '#f1f5f9',
+  200: '#e2e8f0',
+  300: '#cbd5e1',
+  400: '#94A3B8',
+  500: '#64748B',
+  600: '#475569',
+  700: '#334155',
+  800: '#1E293B',
+  900: '#0F172A',
+};
+
+const zinc = {
+  50: '#fafafa',
+  100: '#f4f4f5',
+  200: '#e4e4e7',
+  300: '#d4d4d8',
+  400: '#a1a1aa',
+  500: '#71717A',
+  600: '#52525B',
+  700: '#3F3F46',
+  800: '#27272A',
+  900: '#18181B',
+};
+
+const gray = {
+  50: '#f9fafb',
+  100: '#f3f4f6',
+  200: '#e5e7eb',
+  300: '#d1d5db',
+  400: '#9ca3af',
+  500: '#6b7280',
+  600: '#4b5563',
+  700: '#374151',
+  800: '#1f2937',
+  900: '#111827',
+};
+
 let warned = false;
+
+function color_warn({ from, to }) {
+  if (!warned) {
+    Console.log(`warn - '${from}' has been renamed to '${to}'.`);
+    Console.log(`warn - Please update your color palette to eliminate this warning.`);
+    warned = true;
+  };
+};
 
 export const colors: DefaultColors =  {
   black: '#000',
@@ -141,11 +215,7 @@ export const colors: DefaultColors =  {
   },
   sky,
   get lightBlue() {
-    if (!warned) {
-      Console.log('warn - `lightBlue` has been renamed to `sky`.');
-      Console.log('warn - Please update your color palette to eliminate this warning.');
-      warned = true;
-    }
+    color_warn({ from: "lightBlue", to: "sky" });
     return sky;
   },
   cyan: {
@@ -256,114 +326,31 @@ export const colors: DefaultColors =  {
     800: '#991b1b',
     900: '#7f1d1d',
   },
-  warmGray: {
-    50: '#fafaf9',
-    100: '#f5f5f4',
-    200: '#e7e5e4',
-    300: '#d6d3d1',
-    400: '#a8a29e',
-    500: '#78716c',
-    600: '#57534e',
-    700: '#44403c',
-    800: '#292524',
-    900: '#1c1917',
+  get warmGray() {
+    color_warn({ from: "warmGray", to: "stone" });
+    return stone;
   },
-  trueGray: {
-    50: '#fafafa',
-    100: '#f5f5f5',
-    200: '#e5e5e5',
-    300: '#d4d4d4',
-    400: '#a3a3a3',
-    500: '#737373',
-    600: '#525252',
-    700: '#404040',
-    800: '#262626',
-    900: '#171717',
+  get trueGray() {
+    color_warn({ from: "trueGray", to: "neutral" });
+    return neutral;
   },
-  gray: {
-    50: '#fafafa',
-    100: '#f4f4f5',
-    200: '#e4e4e7',
-    300: '#d4d4d8',
-    400: '#a1a1aa',
-    500: '#71717a',
-    600: '#52525b',
-    700: '#3f3f46',
-    800: '#27272a',
-    900: '#18181b',
+  gray,
+  get coolGray() {
+    color_warn({ from: "coolGray", to: "gray" });
+    return gray;
   },
-  coolGray: {
-    50: '#f9fafb',
-    100: '#f3f4f6',
-    200: '#e5e7eb',
-    300: '#d1d5db',
-    400: '#9ca3af',
-    500: '#6b7280',
-    600: '#4b5563',
-    700: '#374151',
-    800: '#1f2937',
-    900: '#111827',
+  get blueGray() {
+    color_warn({ from: "blueGray", to: "slate" });
+    return slate;
   },
-  blueGray: {
-    50: '#f8fafc',
-    100: '#f1f5f9',
-    200: '#e2e8f0',
-    300: '#cbd5e1',
-    400: '#94a3b8',
-    500: '#64748b',
-    600: '#475569',
-    700: '#334155',
-    800: '#1e293b',
-    900: '#0f172a',
+  slate,
+  zinc,
+  get zink() {
+    color_warn({ from: "zink", to: "zinc" });
+    return zinc;
   },
-  slate: {
-    50: '#f8fafc',
-    100: '#f1f5f9',
-    200: '#e2e8f0',
-    300: '#cbd5e1',
-    400: '#94A3B8',
-    500: '#64748B',
-    600: '#475569',
-    700: '#334155',
-    800: '#1E293B',
-    900: '#0F172A',
-  },
-  zink: {
-    50: '#fafafa',
-    100: '#f4f4f5',
-    200: '#e4e4e7',
-    300: '#d4d4d8',
-    400: '#a1a1aa',
-    500: '#71717A',
-    600: '#52525B',
-    700: '#3F3F46',
-    800: '#27272A',
-    900: '#18181B',
-  },
-  neutral: {
-    50: '#fafafa',
-    100: '#f5f5f5',
-    200: '#e5e5e5',
-    300: '#d4d4d4',
-    400: '#a3a3a3',
-    500: '#737373',
-    600: '#525252',
-    700: '#404040',
-    800: '#262626',
-    900: '#171717',
-  },
-  stone: {
-    50: '#fafaf9',
-    100: '#f5f5f4',
-    200: '#e7e5e4',
-    300: '#d6d3d1',
-    400: '#a8a29e',
-    500: '#78716C',
-    600: '#57534E',
-    700: '#44403C',
-    800: '#292524',
-    900: '#1C1917',
-  },
+  neutral,
+  stone,
   light: {
     50:  '#fdfdfd',
     100: '#fcfcfc',

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -67,7 +67,6 @@ export function toRGBA(color: string): Color | undefined {
 
 export function toRGB(color: string): number[] | undefined {
   const rgba = toRGBA(color);
-  if (!rgba) return;
   rgba.pop();
   return rgba;
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -67,6 +67,7 @@ export function toRGBA(color: string): Color | undefined {
 
 export function toRGB(color: string): number[] | undefined {
   const rgba = toRGBA(color);
+  if (!rgba) return;
   rgba.pop();
   return rgba;
 }


### PR DESCRIPTION
changes:
- added a function for color renamed warnings
- renamed `zink` to `zinc`
- renamed `warmGray` to `stone`
- renamed `blueGray` to `slate`
- renamed `trueGray` to `neutral`
- renamed `coolGray` to `gray`
  * `gray` should have always had the same colors as `coolGray` but for some reason didn't.