### PR TITLE
fix(processor): fix theme.fontSize name error, close #808

### DIFF
--- a/src/lib/utilities/dynamic.ts
+++ b/src/lib/utilities/dynamic.ts
@@ -513,9 +513,9 @@ function text(utility: Utility, { theme }: PluginUtils): Output {
   if (textColor) return textColor;
 
   // handle font sizes
-  const amount = utility.amount;
+  const body = utility.body;
   const fontSizes = toType(theme('fontSize'), 'object') as { [key: string]: FontSize };
-  if (Object.keys(fontSizes).includes(amount)) return new Style(utility.class, generateFontSize(fontSizes[amount])).updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 1, true);
+  if (Object.keys(fontSizes).includes(body)) return new Style(utility.class, generateFontSize(fontSizes[body])).updateMeta('utilities', 'fontSize', pluginOrder.fontSize, 1, true);
   let value = utility.handler
     .handleSquareBrackets(isNumberLead)
     .handleNxl((number: number) => `${number}rem`)

--- a/test/processor/__snapshots__/config.test.ts.yml
+++ b/test/processor/__snapshots__/config.test.ts.yml
@@ -217,6 +217,15 @@ Tools / extend fontFamily with array / css / 0: |-
   .font-sans {
     font-family: Graphik,sans-serif;
   }
+Tools / font size name with multi kebab / css / 0: |-
+  .text-title-1 {
+    font-size: 40px;
+    line-height: 25px;
+  }
+  .text-title\:1 {
+    font-size: 40px;
+    line-height: 25px;
+  }
 Tools / handle colors test / css / 0: |-
   .bg-discord {
     --tw-bg-opacity: 1;

--- a/test/processor/config.test.ts
+++ b/test/processor/config.test.ts
@@ -565,4 +565,17 @@ describe('Config', () => {
     });
     expect(processor.interpret('print:bg-black container').styleSheet.build()).toMatchSnapshot('css');
   });
+
+  // #808
+  it('font size name with multi kebab', () => {
+    const processor = new Processor({
+      theme: {
+        fontSize: {
+          'title-1': ['40px', '25px'],
+          'title:1': ['40px', '25px'],
+        },
+      },
+    });
+    expect(processor.interpret('text-title-1 text-title:1').styleSheet.build()).toMatchSnapshot('css');
+  });
 });


### PR DESCRIPTION
This pr should fix issue #808.
The solution is change font size handler from `amount` to `body`, that makes the key from `'1'` (error) to `'title-1'` (correct).